### PR TITLE
fix for CRM-12404 : 'You do not have permission to execute this url' err...

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -481,7 +481,7 @@ function civicrm_check_permission($args) {
 
     if (
       $arg1 == 'pcp' &&
-      in_array($arg2, array('info'))
+      (!$arg2 || in_array($arg2, array('info')))
     ) {
       return TRUE;
     }
@@ -506,7 +506,7 @@ function civicrm_check_permission($args) {
     }
 
     if ($arg1 == 'pcp' &&
-      in_array($arg2, array('info'))
+      (!$arg2 || in_array($arg2, array('info')))
     ) {
       return TRUE;
     }


### PR DESCRIPTION
'You do not have permission to execute this url' this message is shown after hitting url '&q=civicrm/pcp&action=disable' - on frontend side of wordpress during pcp workflow.

This happens because : 
- Wordpress/civicrm.php contains civicrm_check_permission function which basically allows access only for certain urls for frontend pages visiting.
- handling for '&q=civicrm/pcp' url wasn't done over here and hence this error.
