### PR TITLE
CRM-12523

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -300,6 +300,16 @@ function civicrm_wp_invoke() {
     return '';
   }
 
+  // CRM-12523
+  // WordPress has it's own timezone calculations
+  // Civi relies on the php default timezone which WP
+  // overrides with UTC in wp-settings.php
+  $wpBaseTimezone = date_default_timezone_get();
+  $wpUserTimezone = get_option('timezone_string');
+  if ($wpUserTimezone) {
+    date_default_timezone_set($wpUserTimezone);
+  }
+
   // Add our standard css & js
   CRM_Core_Resources::singleton()->addCoreResources();
 
@@ -332,6 +342,11 @@ function civicrm_wp_invoke() {
   }
 
   CRM_Core_Invoke::invoke($args);
+
+  // restore WP's timezone
+  if ($wpBaseTimezone) {
+    date_default_timezone_set($wpBaseTimezone);
+  }
 }
 
 function civicrm_wp_head() {


### PR DESCRIPTION
---
- CRM-12523: Wordpress timezone settings not carried to CiviCRM
  http://issues.civicrm.org/jira/browse/CRM-12523
