### PR TITLE
CRM-12978 add missing 2nd arguments in civicrm_check_permissions

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -492,7 +492,7 @@ function civicrm_check_permission($args) {
   if (in_array('CiviContribute', $config->enableComponents)) {
     if (
       $arg1 == 'contribute' &&
-      in_array($arg2, array('transact', 'campaign', 'pcp'))
+      in_array($arg2, array('transact', 'campaign', 'pcp', 'updaterecur', 'updatebilling', 'unsubscribe'))
     ) {
       return TRUE;
     }


### PR DESCRIPTION
---
- CRM-12978: Access denied for self-service recurring contribution URLs in WordPress
  http://issues.civicrm.org/jira/browse/CRM-12978
