### PR TITLE
CRM-14244 WordPress plugins that process the_content dump CiviCRM content into head

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -411,7 +411,7 @@ class CiviCRM_For_WordPress {
    */
   public function invoke() {
   
-    if ( !in_the_loop() AND empty($_REQUEST['snippet']) ) {
+    if ( !in_the_loop() && !is_admin() && empty($_REQUEST['snippet']) ) {
       return;
     }
 


### PR DESCRIPTION
In WordPress, CiviCRM echoes its content when the_content is called.  This works fine assuming this only happens within the Loop, but some WordPress plugins process the_content at other times.  This is particularly common for SEO plugins that try to put meta information in the <head>.  The result is that CiviCRM content gets output within the head, above the whole page.

There's a WordPress function called in_the_loop() that checks whether the filter is applied within the Loop; I've made civicrm.php check to see that it's true before proceeding with invoking CiviCRM.  Maggie pointed out that the exception to this is for snippets, so it checks to see if "snippet" is set.
