### PR TITLE
AJAX queries for civicrm/ajax/jqState were never executed causing JavaSc...

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -528,7 +528,8 @@ class CiviCRM_For_WordPress {
         'access_civicrm',
         'CiviCRM',
         array( $this, 'invoke' ),
-        $civilogo
+        $civilogo,
+        1
       );
 
     } else {


### PR DESCRIPTION
AJAX queries for civicrm/ajax/jqState were never executed causing JavaScript errors due to eval(data) expecting JSON but instead receiving HTML. As a result State drop-downs as a result of Country choices in jQuery.chainSelects don't get called.

Why isn't there a simple curl based test that tries to retrieve JSON responses for calls to civicrm/ajax/jqState? This could have been easily caught with an automated test prior to release. I'm also not certain that all edge cases are covered in this if statement and exiting with a return statement in the middle of an invoke step is flirting with more bugs.
