### PR TITLE
CRM-14631 - Put CiviCRM on the top of the left-nav menu, this makes accessing CiviCRM on a WordPress site much more convenient

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -551,7 +551,8 @@ class CiviCRM_For_WordPress {
         'access_civicrm',
         'CiviCRM',
         array( $this, 'invoke' ),
-        $civilogo
+        $civilogo,
+        1
       );
 
     } else {


### PR DESCRIPTION
(This a resubmission of part of https://github.com/civicrm/civicrm-wordpress/pull/43 )
