### PR TITLE
CRM-14989 WordPress plugins that process the_content cause prevent CiviCRM invoke

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -445,7 +445,6 @@ class CiviCRM_For_WordPress {
       return;
     }
 
-    $alreadyInvoked = TRUE;
     if ( ! $this->initialize() ) {
       return '';
     }
@@ -494,6 +493,7 @@ class CiviCRM_For_WordPress {
     if ( $this->isPageRequest() && !in_the_loop() && !is_admin() ) {
       return;
     }
+    $alreadyInvoked = TRUE;
 
     // do the business
     CRM_Core_Invoke::invoke($args);


### PR DESCRIPTION
If the_content is processed in the head, the alreadyInvoked flag gets set to true even though the test for whether CiviCRM should be invoked will stop things later on. With that set to true, it'll never be invoked, even when it's appropriate.  This means blank pages for anyone with a plugin that preprocesses content.

---
- CRM-14989: WordPress plugins that process the_content cause prevent CiviCRM invoke
  https://issues.civicrm.org/jira/browse/CRM-14989
