### PR TITLE
Civi shortcode button should appear only on those WordPress post types that support the editor

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1176,9 +1176,11 @@ class CiviCRM_For_WordPress {
 
   /**
    * @description: callback method for 'media_buttons' hook as set in register_hooks()
-   * @return string HTML for output or empty if CiviCRM not initialized
+   *
+   * @param string $editor_id Unique editor identifier, e.g. 'content'
+   * @return void
    */
-  public function add_form_button( $context ) {
+  public function add_form_button( $editor_id ) {
 
     // add button to WP selected post types, if allowed
     if ( $this->post_type_has_button() ) {


### PR DESCRIPTION
The PR implements the best of the code by @kcristiano in #37, #39, #52 and #58. It updates the deprecated `media_button_context` action to use `media_button` and adds two private methods: 
- `get_post_types_with_editor()` is a generic method to check which WordPress post types support the editor (because there is no point adding the button to those that don't)
- `post_type_has_button()` is a method to assess whether a particular post type should show the Civi button above the editor

The latter method includes a filter so that WordPress plugins can easily choose which post types the button should appear on.
