### PR TITLE
fix petitions shortcode

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1393,7 +1393,6 @@ class CiviCRM_For_WordPress {
     $params = array(
       'version' => 3,
       'is_active' => 1,
-      'activity_type_id' => 'Petition',
       'return' => array('id', 'title'),
 
     );


### PR DESCRIPTION
Fixes the non-appearance of any Petitions in the shortcode modal dialog. Probably needs applying to 4.4 as well, if that's still supported.