### PR TITLE
Only load front-end resources once

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -928,11 +928,19 @@ class CiviCRM_For_WordPress {
    */
   public function front_end_page_load() {
 
+    static $frontend_loaded = FALSE;
+    if ( $frontend_loaded ) {
+      return;
+    }
+
     // add resources for front end
     $this->add_core_resources( TRUE );
 
     // merge CiviCRM's HTML header with the WordPress theme's header
     add_action( 'wp_head', array( $this, 'wp_head' ) );
+
+    // set flag so this only happens once
+    $frontend_loaded = TRUE;
 
   }
 
@@ -945,6 +953,11 @@ class CiviCRM_For_WordPress {
    * @return void
    */
   public function front_end_css_load() {
+
+    static $frontend_css_loaded = FALSE;
+    if ( $frontend_css_loaded ) {
+      return;
+    }
 
     if (!$this->initialize()) {
       return;
@@ -982,6 +995,9 @@ class CiviCRM_For_WordPress {
         'all' // media
       );
     }
+
+    // set flag so this only happens once
+    $frontend_css_loaded = TRUE;
 
   }
 


### PR DESCRIPTION
This is a minor change to make sure that, regardless of the number of times the `front_end_page_load` callback is added to the `wp` hook, the resources are added only once. This can be an issue because of the way some plugins need to pull in resources - see for example:
https://github.com/osseed/com.osseed.eventcalendar/pull/11

I will look at how extensions can offer variants of the `[civicrm ...]` shortcode so that duplicating the functionality of the 'civicrm-wordpress' plugin becomes unnecessary.