### PR TITLE
Override title only when shortcode hijacks post

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -489,7 +489,10 @@ class CiviCRM_For_WordPress_Shortcodes {
       return $title;
     }
 
-    $title = $this->post_titles[$post_id];
+    // shortcodes may or may not override title
+    if ( array_key_exists( $post_id, $this->post_titles ) ) {
+      $title = $this->post_titles[$post_id];
+    }
 
     return $title;
 


### PR DESCRIPTION
When a shortcode is inserted into a post (and the post is displayed on an archive where other posts have Civi shortcodes present) but the shortcode _does not_ hijack the post, the plugin was returning an empty title instead of retaining the post title. This PR fixes that.