### PR TITLE
Fix petitions shortcode in master branch

### DIFF
--- a/includes/civicrm.shortcodes.modal.php
+++ b/includes/civicrm.shortcodes.modal.php
@@ -317,6 +317,7 @@ class CiviCRM_For_WordPress_Shortcodes_Modal {
     $params = array(
       'version' => 3,
       'is_active' => 1,
+      'activity_type_id' => 'Petition',
       'return' => array('id', 'title'),
 
     );


### PR DESCRIPTION
@colemanw I mentioned in https://github.com/civicrm/civicrm-wordpress/pull/62#issuecomment-59988117 that I'd cherry picked https://github.com/civicrm/civicrm-wordpress/commit/94a5cb3246309588faf07700c475f593a9310aab - but in fact there seems to have been a regression in https://github.com/christianwach/civicrm-wordpress/commit/ba7463a8264a73586d44042078e59c75e0e4df68 instead. Thanks for catching this.