### PR TITLE
Load `wp_head` scripts when on Civi admin page (CRM-15937)

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -565,7 +565,7 @@ class CiviCRM_For_WordPress {
       );
 
       // add top level menu item
-      add_menu_page(
+      $menu_page = add_menu_page(
         __( 'CiviCRM', 'civicrm-wordpress' ),
         __( 'CiviCRM', 'civicrm-wordpress' ),
         'access_civicrm',
@@ -573,6 +573,9 @@ class CiviCRM_For_WordPress {
         array( $this, 'invoke' ),
         $civilogo
       );
+
+      // add CiviCRM scripts and styles to admin head
+      add_action( 'admin_head-' . $menu_page, array( $this, 'wp_head' ), 50 );
 
     } else {
 


### PR DESCRIPTION
Solves https://issues.civicrm.org/jira/browse/CRM-15937

@kcristiano @colemanw I can confirm that the JS and CSS fail to load once Civi is installed. This PR fixes the script loading. I'll take a look at the default for 4.5.x as well.