### PR TITLE
CRM-16421 Rid Code base of references to 'wp-content'

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -799,7 +799,7 @@ class CiviCRM_For_WordPress {
       'index.php';
 
     // Notice: Undefined variable: siteDir in:
-    // wp-content/plugins/civicrm/civicrm/install/index.php on line 456
+    // CIVICRM_PLUGIN_DIR/civicrm/install/index.php on line 456
     include ( $installFile );
 
   }

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ CiviCRM is localized in over 20 languages including: Chinese (Taiwan, China), Du
 
 1. Download CiviCRM for WordPress from the [CiviCRM website](https://civicrm.org/download)
 1. Extract the plugin archive 
-1. Upload plugin files to your `/wp-content/plugins/` directory
+1. Upload plugin files to your plugins directory, normally `/wp-content/plugins/`
 1. Follow the instructions on the [CiviCRM website](http://wiki.civicrm.org/confluence/display/CRMDOC/WordPress+Installation+Guide+for+CiviCRM+4.5)
 
 


### PR DESCRIPTION
* [CRM-16421: Work to get CiviCRM for WordPress in WordPress' official Repository](https://issues.civicrm.org/jira/browse/CRM-16421)