### PR TITLE
CRM-17804: Better checks for screen object in WordPress admin

### DIFF
--- a/includes/civicrm.shortcodes.modal.php
+++ b/includes/civicrm.shortcodes.modal.php
@@ -163,6 +163,9 @@ class CiviCRM_For_WordPress_Shortcodes_Modal {
     // get screen object
     $screen = get_current_screen();
 
+    // bail if no post type (e.g. Ninja Forms)
+    if ( ! isset( $screen->post_type ) ) return;
+
     // get post types that support the editor
     $capable_post_types = $this->get_post_types_with_editor();
 


### PR DESCRIPTION
Fixes issue originally reported [on StackExchange](http://civicrm.stackexchange.com/questions/6829/does-civicrm-work-with-ninja-forms/6850).