### PR TITLE
Search multisite directories for civicrm.settings.php

### DIFF
--- a/civicrm.config.php.wordpress
+++ b/civicrm.config.php.wordpress
@@ -292,6 +292,8 @@ class Bootstrap {
         $wpDirs = array(
           $cmsRoot . '/*/uploads/civicrm',
           $cmsRoot . '/*/plugins/civicrm',
+          $cmsRoot . '/*/uploads/sites/*/civicrm',
+          $cmsRoot . '/*/blogs.dir/*/files/civicrm',
         );
         $settings = $this->findFirstFile($wpDirs, 'civicrm.settings.php');
         break;


### PR DESCRIPTION
Jira issue: https://issues.civicrm.org/jira/browse/CRM-18099

This may be more a more complicated issue than this solution alone can fix, depending on how CiviCRM has been installed. It's possible, for example, for CiviCRM to be enabled on more than one network, which will lead to more than one CiviCRM "files" directory. The search routine fails to take this into account. Still, this fixes the simplest use cases in the meantime.