### PR TITLE
CRM-18062: Mailing processing ignores timezone, and sends mailings at wrong time

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -206,7 +206,7 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
 
             // CRM-18062: Set CiviCRM timezone if any
             $wpBaseTimezone = date_default_timezone_get();
-            $wpUserTimezone = get_option('timezone_string');
+            $wpUserTimezone = $this->getOption('timezone', get_option('timezone_string'));
             if ($wpUserTimezone) {
               date_default_timezone_set($wpUserTimezone);
               CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -203,7 +203,21 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
             }
 
             civicrm_initialize();
+
+            // CRM-18062: Set CiviCRM timezone if any
+            $wpBaseTimezone = date_default_timezone_get();
+            $wpUserTimezone = get_option('timezone_string');
+            if ($wpUserTimezone) {
+              date_default_timezone_set($wpUserTimezone);
+              CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+            }
+
             $result = civicrm_api($entity, $action, $params);
+
+            // restore WP's timezone
+            if ($wpBaseTimezone) {
+              date_default_timezone_set($wpBaseTimezone);
+            }
 
             switch ($this->getOption('out', 'pretty')) {
 


### PR DESCRIPTION
* [CRM-18062: Mailing processing ignores timezone, and sends mailings at wrong time](https://issues.civicrm.org/jira/browse/CRM-18062)