### PR TITLE
CRM-18038 - civicrm.config.php.wordpress - Only coerce $_SERVER in CLI

### DIFF
--- a/civicrm.config.php.wordpress
+++ b/civicrm.config.php.wordpress
@@ -135,12 +135,14 @@ class Bootstrap {
       }
 
       list ($cmsType, $cmsBasePath) = $this->findCmsRoot($this->getSearchDir());
-      $_SERVER['SCRIPT_FILENAME'] = $cmsBasePath . '/index.php';
-      $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
-      $_SERVER['SERVER_SOFTWARE'] = NULL;
-      $_SERVER['REQUEST_METHOD'] = 'GET';
-      if (ord($_SERVER['SCRIPT_NAME']) != 47) {
-        $_SERVER['SCRIPT_NAME'] = '/' . $_SERVER['SCRIPT_NAME'];
+      if (PHP_SAPI === 'cli') {
+        $_SERVER['SCRIPT_FILENAME'] = $cmsBasePath . '/index.php';
+        $_SERVER['REMOTE_ADDR'] = "127.0.0.1";
+        $_SERVER['SERVER_SOFTWARE'] = NULL;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        if (ord($_SERVER['SCRIPT_NAME']) != 47) {
+          $_SERVER['SCRIPT_NAME'] = '/' . $_SERVER['SCRIPT_NAME'];
+        }
       }
     }
 


### PR DESCRIPTION
This file includes some overrides to set $_SERVER, which were originally
added for CLI support.  However, they are inappropriate when booting within
a standard HTTP request.

---

 * [CRM-18038: REST API Seems Broken - error "All requests that modify the database must be http POST, not GET." eronously raised](https://issues.civicrm.org/jira/browse/CRM-18038)