### PR TITLE
CRM-16421 CRM-17633 WIP Changes to support WP in it's own directory

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1422,7 +1422,7 @@ class CiviCRM_For_WordPress {
   public function get_base_url($absolute, $frontend, $forceBackend) {
     $config = CRM_Core_Config::singleton();
     if (!defined('CIVICRM_UF_ADMINURL')) {
-      define('CIVICRM_UF_ADMINURL', CIVICRM_UF_BASEURL . '/wp-admin/');
+      define('CIVICRM_UF_ADMINURL', CIVICRM_UF_BASEURL . 'wp-admin/');
     }
     if (!defined('CIVICRM_UF_WP_BASEURL')) {
       define('CIVICRM_UF_WP_BASEURL', CIVICRM_UF_BASEURL );

--- a/civicrm.php
+++ b/civicrm.php
@@ -1420,29 +1420,26 @@ class CiviCRM_For_WordPress {
    * @return mixed|null|string
    */
   public function get_base_url($absolute, $frontend, $forceBackend) {
-    $config    = CRM_Core_Config::singleton();
-
-    if (!isset($config->useFrameworkRelativeBase)) {
-      $base = parse_url($config->userFrameworkBaseURL);
-      $config->useFrameworkRelativeBase = $base['path'];
+    $config = CRM_Core_Config::singleton();
+    if (!defined('CIVICRM_UF_ADMINURL')) {
+      define('CIVICRM_UF_ADMINURL', CIVICRM_UF_BASEURL . '/wp-admin/');
     }
-
-    $base = $absolute ? $config->userFrameworkBaseURL : $config->useFrameworkRelativeBase;
-
+    if (!defined('CIVICRM_UF_WP_BASEURL')) {
+      define('CIVICRM_UF_WP_BASEURL', CIVICRM_UF_BASEURL );
+    }
     if ((is_admin() && !$frontend) || $forceBackend) {
-      $base .= admin_url( 'admin.php' );
-      return $base;
+      $url = CIVICRM_UF_ADMINURL . 'admin.php';
+      return $url;
     }
     elseif (defined('CIVICRM_UF_WP_BASEPAGE')) {
-      $base .= CIVICRM_UF_WP_BASEPAGE;
-      return $base;
+      $url = CIVICRM_UF_WP_BASEURL  . CIVICRM_UF_WP_BASEPAGE  ;
+      return $url;
     }
     elseif (isset($config->wpBasePage)) {
-      $base .= $config->wpBasePage;
-      return $base;
+      $url = CIVICRM_UF_WP_BASEURL  . $config->wpBasePage;
+      return $url;
     }
-
-    return $base;
+    return $absolute ? $url :  preg_replace(';https?://[^/]+/;', '/', $url);
   }
 
 


### PR DESCRIPTION
Syncronise get_base_url funcyion in civicrm.php with CRM_Utils_System_WordPress

---

 * [CRM-16421: Work to get CiviCRM for WordPress in WordPress' official Repository](https://issues.civicrm.org/jira/browse/CRM-16421)
 * [CRM-17633: WordPress in own directory breaks CiviCRM](https://issues.civicrm.org/jira/browse/CRM-17633)