### PR TITLE
CRM-18062 backport

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -198,7 +198,21 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
             }
 
             civicrm_initialize();
+
+            // CRM-18062: Set CiviCRM timezone if any
+            $wpBaseTimezone = date_default_timezone_get();
+            $wpUserTimezone = get_option('timezone_string');
+            if ($wpUserTimezone) {
+              date_default_timezone_set($wpUserTimezone);
+              CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+            }
+
             $result = civicrm_api($entity, $action, $params);
+
+            // restore WP's timezone
+            if ($wpBaseTimezone) {
+              date_default_timezone_set($wpBaseTimezone);
+            }
 
             switch ($this->getOption('out', 'pretty')) {
 

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -201,7 +201,7 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
 
             // CRM-18062: Set CiviCRM timezone if any
             $wpBaseTimezone = date_default_timezone_get();
-            $wpUserTimezone = get_option('timezone_string');
+            $wpUserTimezone = $this->getOption('timezone', get_option('timezone_string'));
             if ($wpUserTimezone) {
               date_default_timezone_set($wpUserTimezone);
               CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();


### PR DESCRIPTION
Just the same commits from 4.7 - applied and tested.

---
- [CRM-18602](https://issues.civicrm.org/jira/browse/CRM-18602)

---
- [CRM-18062: Mailing processing ignores timezone, and sends mailings at wrong time](https://issues.civicrm.org/jira/browse/CRM-18062)
