### PR TITLE
CRM-18799 - remove use of exec in WordPress bootstrap

### DIFF
--- a/civicrm.config.php.wordpress
+++ b/civicrm.config.php.wordpress
@@ -396,20 +396,23 @@ class Bootstrap {
    */
   protected function getSearchDir() {
     if ($this->options['search'] === TRUE) {
-      // exec(pwd) works better with symlinked source trees, but it's
-      // probably not portable to Windows.
-      if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+      if ($_SERVER['SCRIPT_FILENAME']) {
+        return dirname($_SERVER['SCRIPT_FILENAME']);
+      }
+      // getenv('PWD') works better with symlinked source trees, but it's
+      // not portable to Windows.
+      elseif (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
         return getcwd();
       }
       else {
-        exec('pwd', $output);
-        return trim(implode("\n", $output));
+        return getenv('PWD');
       }
     }
     else {
       return $this->options['search'];
     }
   }
+
 }
 
 \Civi\Cv\Bootstrap::singleton()->boot();


### PR DESCRIPTION
* [CRM-18799: different server requirements between 4.7.x and 4.6.x](https://issues.civicrm.org/jira/browse/CRM-18799)