### PR TITLE
CRM-21084: Extensibility improvement

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -229,8 +229,7 @@ class CiviCRM_For_WordPress_Shortcodes {
     $this->shortcodes_parsed = TRUE;
 
     // broadcast this as well
-    do_action( 'civicrm_shortcodes_parsed' );
-
+    do_action('civicrm_shortcodes_parsed', $this->shortcodes);
   }
 
 


### PR DESCRIPTION
Makes available to WP devs information about the shortcodes in use on the current page.

---

 * [CRM-21084: Give themers and plugin devs ability to test if CiviCRM is currently being displayed in a WordPress shortcode](https://issues.civicrm.org/jira/browse/CRM-21084)