### PR TITLE
Fix parameter parsing in wp-cli civicrm api.

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -174,7 +174,6 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 		 * Implementation of command 'api'
 		 */
 		private function api() {
-
 			$defaults = array( 'version' => 3 );
 
 			array_shift( $this->args );
@@ -182,8 +181,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 			array_shift( $this->args );
 
 			# parse $params
-
-			$format = $this->getOption( 'in', 'args' )
+			$format = $this->getOption( 'in', 'args' );
 			switch ( $format ) {
 
 				# input params supplied via args ..

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -179,16 +179,18 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 
 			array_shift( $this->args );
 			list( $entity, $action ) = explode( '.', $this->args[0] );
+			array_shift( $this->args );
 
 			# parse $params
 
-			switch ( $this->getOption( 'in', 'args' ) ) {
+			$format = $this->getOption( 'in', 'args' )
+			switch ( $format ) {
 
 				# input params supplied via args ..
 				case 'args':
 					$params = $defaults;
 					foreach ( $this->args as $arg ) {
-						preg_match( '/^( [^=]+ )=( .* )$/', $arg, $matches );
+						preg_match( '/^([^=]+)=(.*)$/', $arg, $matches );
 						$params[ $matches[1] ] = $matches[2];
 					}
 					break;

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -174,6 +174,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 		 * Implementation of command 'api'
 		 */
 		private function api() {
+
 			$defaults = array( 'version' => 3 );
 
 			array_shift( $this->args );


### PR DESCRIPTION
The entity and action were also being parsed as an invalid parameter.
This was fixed by shifting the args array after parsing them.

An unassigned $format variable was being referenced inside of the
default case for the switch statement if the --in option was neither
args nor json. This was fixed by assigning $format to the output of
getOption rather than switching on getOption directly.

The parameter matching regex had spaces added to it in pull request #110
that caused arguments of the format foo=bar to not be matched correctly,
so no parameters were actually being passed to the underlying api
method. The spaces were removed from the regex and the parsing worked.

Two other regex matches had spaces added to them by pull request #110
that I have not touched, but they seem suspect.