### PR TITLE
CRM-21166: WP-CLI commands fail due to whitespace in regex  Remove wh…

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -1136,7 +1136,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 
 			// Get phptype and dbsyntax
 			// $str => phptype( dbsyntax )
-			if ( preg_match( '|^( .+? )\( ( .*? )\ )$|', $str, $arr ) ) {
+			if ( preg_match( '|^(.+?)\((.*?)\)$|', $str, $arr ) ) {
 				$parsed['phptype']  = $arr[1];
 				$parsed['dbsyntax'] = ! $arr[2] ? $arr[1] : $arr[2];
 			} else {
@@ -1163,7 +1163,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 
 			// Find protocol and hostspec
 
-			if ( preg_match( '|^( [^( ]+ )\( ( .*? )\ )/?( .*? )$|', $dsn, $match ) ) {
+			if ( preg_match( '|^([^(]+)\((.*? )\)/?(.*?)$|', $dsn, $match ) ) {
 				// $dsn => proto( proto_opts )/database
 				$proto       = $match[1];
 				$proto_opts  = $match[2] ? $match[2] : false;

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -1163,7 +1163,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 
 			// Find protocol and hostspec
 
-			if ( preg_match( '|^([^(]+)\((.*? )\)/?(.*?)$|', $dsn, $match ) ) {
+			if ( preg_match( '|^([^(]+)\((.*?)\)/?(.*?)$|', $dsn, $match ) ) {
 				// $dsn => proto( proto_opts )/database
 				$proto       = $match[1];
 				$proto_opts  = $match[2] ? $match[2] : false;


### PR DESCRIPTION
…itespace from regex on parseDSN function.