### PR TITLE
CRM-21564: Change from using exec to WP_CLI::Launch

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -1293,7 +1293,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 			if ( $tarfile = $this->getOption( $option, false ) ) {
 				WP_CLI::launch( "gzip -d $tarfile" );
 				$tarfile = substr( $tarfile, 0, strlen( $tarfile ) - 3 );
-				$this->exec( "tar -xf $tarfile -C \"$destination_path\"" );
+				WP_CLI::launch( "tar -xf $tarfile -C \"$destination_path\"" );
 				return true;
 			} else {
 				return false;


### PR DESCRIPTION
exec does not seem to be available on all systems. Also makes the code
more consistent for running external processes.

This was discussed in the CiviCRM chat in the wordpress channel about a month ago, have finally got around to pushing this PR

---

 * [CRM-21564: Changing from using exec to WP_CLI::Launch](https://issues.civicrm.org/jira/browse/CRM-21564)