### PR TITLE
CRM-21565: Change mkdir to use correct and more secure mode numbers

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -654,7 +654,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 
 			$restore_backup_dir .= '/plugins/restore/' . $date;
 
-			if ( ! mkdir( $restore_backup_dir, 777, true ) ) {
+			if ( ! mkdir( $restore_backup_dir, 0755, true ) ) {
 				return WP_CLI::error( 'Failed creating directory: ' . $restore_backup_dir );
 			}
 
@@ -999,7 +999,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 			# begin upgrade
 
 			$backup_dir .= '/plugins/' . $date;
-			if ( ! mkdir( $backup_dir, 777, true ) ) {
+			if ( ! mkdir( $backup_dir, 0755, true ) ) {
 				return WP_CLI::error( 'Failed creating directory: ' . $backup_dir );
 			}
 

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -379,7 +379,7 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 			$upload_dir = wp_upload_dir();
 			$settings_dir = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR;
 			civicrm_setup( $upload_dir['basedir'] . DIRECTORY_SEPARATOR );
-			WP_CLI::launch( "chmod 0777 $settings_dir -R" );
+			WP_CLI::launch( "chmod 0755 $settings_dir -R" );
 
 			# now we've got some files in place, require PEAR DB and check db setup
 			$dsn = "mysql://{$dbuser}:{$dbpass}@{$dbhost}/{$dbname}?new_link=true";


### PR DESCRIPTION
The original setting of `777` is not a valid mode number for mkdir, and
should have been `0777` as it is an octal number. This has been changed
to `0755` to be in keeping with the wordpress permission scheme, which
is readable by all but only writeable by the current user. As these are
for backups a more strict setting may be preferable, but this is a
reasonable compromise

---

 * [CRM-21565: Change mkdir to use correct and more secure mode numbers](https://issues.civicrm.org/jira/browse/CRM-21565)