### PR TITLE
Installation - If available, use the new installer package

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -805,6 +805,7 @@ class CiviCRM_For_WordPress {
         require_once $loader;
         require_once implode(DIRECTORY_SEPARATOR, [$civicrmCore, 'CRM', 'Core', 'ClassLoader.php']);
         CRM_Core_ClassLoader::singleton()->register();
+        \Civi\Setup::assertProtocolCompatibility(0.1);
         \Civi\Setup::init([
           'cms' => 'WordPress',
           'srcPath' => $civicrmCore,

--- a/civicrm.php
+++ b/civicrm.php
@@ -792,6 +792,36 @@ class CiviCRM_For_WordPress {
    * @return void
    */
   public function run_installer() {
+    $civicrmCore = CIVICRM_PLUGIN_DIR . 'civicrm';
+
+    $setupPaths = array(
+      implode(DIRECTORY_SEPARATOR, ['vendor', 'civicrm', 'civicrm-setup']),
+      implode(DIRECTORY_SEPARATOR, ['packages', 'civicrm-setup',]),
+      implode(DIRECTORY_SEPARATOR, ['setup']),
+    );
+    foreach ($setupPaths as $setupPath) {
+      $loader = implode(DIRECTORY_SEPARATOR, [$civicrmCore, $setupPath, 'civicrm-setup-autoload.php']);
+      if (file_exists($loader)) {
+        require_once $loader;
+        require_once implode(DIRECTORY_SEPARATOR, [$civicrmCore, 'CRM', 'Core', 'ClassLoader.php']);
+        CRM_Core_ClassLoader::singleton()->register();
+        \Civi\Setup::init([
+          'cms' => 'WordPress',
+          'srcPath' => $civicrmCore,
+          'setupPath' => dirname($loader),
+        ]);
+        $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
+        $ctrl->setUrls(array(
+          'ctrl' => admin_url() . "options-general.php?page=civicrm-install",
+          'res' => CIVICRM_PLUGIN_URL . 'civicrm/' . strtr($setupPath, DIRECTORY_SEPARATOR, '/') . '/res/',
+          'jquery.js' => CIVICRM_PLUGIN_URL . 'civicrm/bower_components/jquery/dist/jquery.min.js',
+          'font-awesome.css' => CIVICRM_PLUGIN_URL . 'civicrm/bower_components/font-awesome/css/font-awesome.min.css',
+          'finished' => admin_url('admin.php?page=CiviCRM&q=civicrm&reset=1'),
+        ));
+        \Civi\Setup\BasicRunner::run($ctrl);
+        return;
+      }
+    }
 
     // uses CIVICRM_PLUGIN_DIR instead of WP_PLUGIN_DIR
     $installFile =


### PR DESCRIPTION
`civicrm-core` includes an installer (`civicrm/install/index.php`), but this
code is difficult to update/maintain.  The `civicrm-setup`
(http://github.com/civicrm/civicrm-setup/) package is a "leap" to replace it
with a more maintainable library.

This patch uses whichever is available.

Before
------
 * The page `civicrm-install` always uses `civicrm/install/index.php`.

After
-----
 * The page `civicrm-install` picks the first available installer UI, either:
   * `civicrm/vendor/civicrm/civicrm-setup/*` (`Civi\Setup::createController()`)
   * `civicrm/packages/civicrm-setup/*` (`Civi\Setup::createController()`)
   * `civicrm/setup/*` (`Civi\Setup::createController()`)
   * `civicrm/install/index.php`

Comments
-----------
 * If you actually want to try it out, just clone http://github.com/civicrm/civicrm-setup/ and put it in `civicrm/packages/civicrm-setup`.