### PR TITLE
CRM-16421 - Installation - Update to newer protocol

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -801,15 +801,14 @@ class CiviCRM_For_WordPress {
     );
     foreach ($setupPaths as $setupPath) {
       $loader = implode(DIRECTORY_SEPARATOR, [$civicrmCore, $setupPath, 'civicrm-setup-autoload.php']);
-      if (file_exists($loader)) {
+      if (file_exists($civicrmCore . DIRECTORY_SEPARATOR . '.use-civicrm-setup') && file_exists($loader)) {
         require_once $loader;
         require_once implode(DIRECTORY_SEPARATOR, [$civicrmCore, 'CRM', 'Core', 'ClassLoader.php']);
         CRM_Core_ClassLoader::singleton()->register();
-        \Civi\Setup::assertProtocolCompatibility(0.1);
+        \Civi\Setup::assertProtocolCompatibility(1.0);
         \Civi\Setup::init([
           'cms' => 'WordPress',
           'srcPath' => $civicrmCore,
-          'setupPath' => dirname($loader),
         ]);
         $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
         $ctrl->setUrls(array(


### PR DESCRIPTION
This is a follow-up to the recently-merged #121. 

In #121, it was expected that some systems would opt-in to using the new installer, and others would opt-out. The mechanism for opt-in/opt-out was to download (or not download) the `civicrm-setup` folder.

This patch revises the protocol -- you can download the `civicrm-setup` folder regardless of preference. To indicate the preferred installer, create (or delete) a file named `.use-civicrm-setup`. In terms of the overall build/distribution infrastructure, it's easier to support this protocol.

---

 * [CRM-16421: Work to get CiviCRM for WordPress in WordPress' official Repository](https://issues.civicrm.org/jira/browse/CRM-16421)