### PR TITLE
CRM-21788 Clean URLs (Proof of Concept)

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -302,12 +302,6 @@ class CiviCRM_For_WordPress {
       session_start();
     }
 
-    // save original arrays
-    $this->civi_get     = $_GET;
-    $this->civi_post    = $_POST;
-    $this->civi_cookie  = $_COOKIE;
-    $this->civi_request = $_REQUEST;
-
     // get classes and instantiate
     $this->include_files();
 
@@ -1380,10 +1374,10 @@ class CiviCRM_For_WordPress {
     $this->wp_request = $_REQUEST;
 
     // reassign globals
-    $_GET     = stripslashes_deep($this->civi_get);
-    $_POST    = stripslashes_deep($this->civi_post);
-    $_COOKIE  = stripslashes_deep($this->civi_cookie);
-    $_REQUEST = stripslashes_deep($this->civi_request);
+    $_GET     = stripslashes_deep( $_GET );
+    $_POST    = stripslashes_deep( $_POST );
+    $_COOKIE  = stripslashes_deep( $_COOKIE );
+    $_REQUEST = stripslashes_deep( $_REQUEST );
 
     // test for query var
     $q = get_query_var( 'q' );

--- a/civicrm.php
+++ b/civicrm.php
@@ -545,7 +545,7 @@ class CiviCRM_For_WordPress {
     // register user hooks
     $this->users->register_hooks();
 
-	// have we flushed rewrite rules?
+    // have we flushed rewrite rules?
     if ( get_option( 'civicrm_rules_flushed' ) !== 'true' ) {
 
       // apply custom rewrite rules, then flush rules afterwards
@@ -1389,34 +1389,34 @@ class CiviCRM_For_WordPress {
     $q = get_query_var( 'q' );
     if (!empty($q)) {
 
-		$page = get_query_var( 'page' );
-		$reset = get_query_var( 'reset' );
-		$id = get_query_var( 'id' );
-		$html = get_query_var( 'html' );
-		$snippet = get_query_var( 'snippet' );
+      $page = get_query_var( 'page' );
+      $reset = get_query_var( 'reset' );
+      $id = get_query_var( 'id' );
+      $html = get_query_var( 'html' );
+      $snippet = get_query_var( 'snippet' );
 
-		$action = get_query_var( 'action' );
-		$mode = get_query_var( 'mode' );
-		$cid = get_query_var( 'cid' );
-		$gid = get_query_var( 'gid' );
-		$sid = get_query_var( 'sid' );
-		$cs = get_query_var( 'cs' );
-		$force = get_query_var( 'force' );
+      $action = get_query_var( 'action' );
+      $mode = get_query_var( 'mode' );
+      $cid = get_query_var( 'cid' );
+      $gid = get_query_var( 'gid' );
+      $sid = get_query_var( 'sid' );
+      $cs = get_query_var( 'cs' );
+      $force = get_query_var( 'force' );
 
-		$_REQUEST['q'] = $_GET['q'] = $q;
-		$_REQUEST['page'] = $_GET['page'] = 'CiviCRM';
-		if (!empty($reset)) { $_REQUEST['reset'] = $_GET['reset'] = $reset; }
-		if (!empty($id)) { $_REQUEST['id'] = $_GET['id'] = $id; }
-		if (!empty($html)) { $_REQUEST['html'] = $_GET['html'] = $html; }
-		if (!empty($snippet)) { $_REQUEST['snippet'] = $_GET['snippet'] = $snippet; }
+      $_REQUEST['q'] = $_GET['q'] = $q;
+      $_REQUEST['page'] = $_GET['page'] = 'CiviCRM';
+      if (!empty($reset)) { $_REQUEST['reset'] = $_GET['reset'] = $reset; }
+      if (!empty($id)) { $_REQUEST['id'] = $_GET['id'] = $id; }
+      if (!empty($html)) { $_REQUEST['html'] = $_GET['html'] = $html; }
+      if (!empty($snippet)) { $_REQUEST['snippet'] = $_GET['snippet'] = $snippet; }
 
-		if (!empty($action)) { $_REQUEST['action'] = $_GET['action'] = $action; }
-		if (!empty($mode)) { $_REQUEST['mode'] = $_GET['mode'] = $mode; }
-		if (!empty($cid)) { $_REQUEST['cid'] = $_GET['cid'] = $cid; }
-		if (!empty($gid)) { $_REQUEST['gid'] = $_GET['gid'] = $gid; }
-		if (!empty($sid)) { $_REQUEST['sid'] = $_GET['sid'] = $sid; }
-		if (!empty($cs)) { $_REQUEST['cs'] = $_GET['cs'] = $cs; }
-		if (!empty($force)) { $_REQUEST['force'] = $_GET['force'] = $force; }
+      if (!empty($action)) { $_REQUEST['action'] = $_GET['action'] = $action; }
+      if (!empty($mode)) { $_REQUEST['mode'] = $_GET['mode'] = $mode; }
+      if (!empty($cid)) { $_REQUEST['cid'] = $_GET['cid'] = $cid; }
+      if (!empty($gid)) { $_REQUEST['gid'] = $_GET['gid'] = $gid; }
+      if (!empty($sid)) { $_REQUEST['sid'] = $_GET['sid'] = $sid; }
+      if (!empty($cs)) { $_REQUEST['cs'] = $_GET['cs'] = $cs; }
+      if (!empty($force)) { $_REQUEST['force'] = $_GET['force'] = $force; }
 
     }
 

--- a/civicrm.php
+++ b/civicrm.php
@@ -545,8 +545,21 @@ class CiviCRM_For_WordPress {
     // register user hooks
     $this->users->register_hooks();
 
-    // custom rewrite rules
-    $this->rewrite_rules();
+	// have we flushed rewrite rules?
+    if ( get_option( 'civicrm_rules_flushed' ) !== 'true' ) {
+
+      // apply custom rewrite rules, then flush rules afterwards
+      $this->rewrite_rules( true );
+
+      // set a one-time-only option to flag that this has been done
+      add_option( 'civicrm_rules_flushed', 'true' );
+
+    } else {
+
+      // apply custom rewrite rules normally
+      $this->rewrite_rules();
+
+    }
 
     // add our query vars
     add_filter( 'query_vars', array( $this, 'query_vars' ) );

--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -294,22 +294,40 @@ class CiviCRM_For_WordPress_Basepage {
    *   The complete URL to the page as it should be accessed.
    */
   public function basepage_canonical_url( $canonical ) {
-    // It would be better to specify which params are okay to accept as the
-    // canonical URLs, but this will work for the time being.
-    if ( empty( $_GET['page'] )
-      || empty( $_GET['q'] )
-      || 'CiviCRM' !== $_GET['page'] ) {
-      return $canonical;
+
+    // access Civi config object
+    $config = CRM_Core_Config::singleton();
+
+    // retain old logic when not using clean URLs
+    if (!$config->cleanURL) {
+
+      // It would be better to specify which params are okay to accept as the
+      // canonical URLs, but this will work for the time being.
+      if ( empty( $_GET['page'] )
+        || empty( $_GET['q'] )
+        || 'CiviCRM' !== $_GET['page'] ) {
+        return $canonical;
+      }
+      $path = $_GET['q'];
+      unset( $_GET['q'] );
+      unset( $_GET['page'] );
+      $query = http_build_query( $_GET );
+
     }
-    $path = $_GET['q'];
-    unset( $_GET['q'] );
-    unset( $_GET['page'] );
-    $query = http_build_query( $_GET );
+    else {
+
+      $argdata = $this->civi->get_request_args();
+      $path = $argdata['argString'];
+      $query = http_build_query( $_GET );
+
+    }
 
     // We should, however, build the URL the way that CiviCRM expects it to be
     // (rather than through some other funny base page).
     return CRM_Utils_System::url( $path, $query );
+
   }
+
 
   /**
    * Get CiviCRM base page template.

--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -223,15 +223,15 @@ class CiviCRM_For_WordPress_Basepage {
       $separator_code = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
       $separator_array = WPSEO_Option_Titles::get_instance()->get_separator_options();
       if ( array_key_exists( $separator_code, $separator_array ) ) {
-      	$separator = $separator_array[$separator_code];
+        $separator = $separator_array[$separator_code];
       }
     }
 
     // construct title depending on separator location
     if ( $separator_location == 'right' ) {
-	  $title = $this->basepage_title . " $separator " . get_bloginfo( 'name', 'display' );
+      $title = $this->basepage_title . " $separator " . get_bloginfo( 'name', 'display' );
     } else {
-	  $title = get_bloginfo( 'name', 'display' ) . " $separator " . $this->basepage_title;
+      $title = get_bloginfo( 'name', 'display' ) . " $separator " . $this->basepage_title;
     }
 
     // return modified title
@@ -407,34 +407,34 @@ class CiviCRM_For_WordPress_Basepage {
    */
   public function add_body_classes( $classes ) {
 
-  	 $args = $this->civi->get_request_args();
+    $args = $this->civi->get_request_args();
 
-  	 // bail if we don't have any
-  	 if ( is_null( $args['argString'] ) ) {
-  	   return $classes;
-  	 }
+    // bail if we don't have any
+    if ( is_null( $args['argString'] ) ) {
+      return $classes;
+    }
 
-  	 // check for top level - it can be assumed this always 'civicrm'
-  	 if ( isset( $args['args'][0] ) AND ! empty( $args['args'][0] ) ) {
-  	   $classes[] = $args['args'][0];
-  	 }
+    // check for top level - it can be assumed this always 'civicrm'
+    if ( isset( $args['args'][0] ) AND ! empty( $args['args'][0] ) ) {
+      $classes[] = $args['args'][0];
+    }
 
-  	 // check for second level - the component
-  	 if ( isset( $args['args'][1] ) AND ! empty( $args['args'][1] ) ) {
-  	   $classes[] = $args['args'][0] . '-' . $args['args'][1];
-  	 }
+    // check for second level - the component
+    if ( isset( $args['args'][1] ) AND ! empty( $args['args'][1] ) ) {
+      $classes[] = $args['args'][0] . '-' . $args['args'][1];
+    }
 
-  	 // check for third level - the component's configuration
-  	 if ( isset( $args['args'][2] ) AND ! empty( $args['args'][2] ) ) {
-  	   $classes[] = $args['args'][0] . '-' . $args['args'][1] . '-' . $args['args'][2];
-  	 }
+    // check for third level - the component's configuration
+    if ( isset( $args['args'][2] ) AND ! empty( $args['args'][2] ) ) {
+      $classes[] = $args['args'][0] . '-' . $args['args'][1] . '-' . $args['args'][2];
+    }
 
-  	 // check for fourth level - because well, why not?
-  	 if ( isset( $args['args'][3] ) AND ! empty( $args['args'][3] ) ) {
-  	   $classes[] = $args['args'][0] . '-' . $args['args'][1] . '-' . $args['args'][2] . '-' . $args['args'][3];
-  	 }
+    // check for fourth level - because well, why not?
+    if ( isset( $args['args'][3] ) AND ! empty( $args['args'][3] ) ) {
+      $classes[] = $args['args'][0] . '-' . $args['args'][1] . '-' . $args['args'][2] . '-' . $args['args'][3];
+    }
 
-  	 return $classes;
+    return $classes;
 
   }
 

--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -273,7 +273,7 @@ class CiviCRM_For_WordPress_Shortcodes {
     // invoke() requires environment variables to be set
     foreach ( $args as $key => $value ) {
       if ( $value !== NULL ) {
-      	set_query_var($key, $value);
+        set_query_var($key, $value);
         //$_REQUEST[$key] = $_GET[$key] = $value;
       }
     }

--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -273,7 +273,8 @@ class CiviCRM_For_WordPress_Shortcodes {
     // invoke() requires environment variables to be set
     foreach ( $args as $key => $value ) {
       if ( $value !== NULL ) {
-        $_REQUEST[$key] = $_GET[$key] = $value;
+      	set_query_var($key, $value);
+        //$_REQUEST[$key] = $_GET[$key] = $value;
       }
     }
 
@@ -351,18 +352,35 @@ class CiviCRM_For_WordPress_Shortcodes {
       // $absolute, $frontend, $forceBackend
       $base_url = $this->civi->get_base_url(TRUE, FALSE, FALSE);
 
-      // construct query parts
-      $queryParts = array();
-      $queryParts[] = 'page=CiviCRM';
-      if (isset($args['q'])) {
-        $queryParts[] = 'q=' . $args['q'];
-      }
-      if (isset($query)) {
-        $queryParts[] = $query;
-      }
+      // when not using clean URLs
+      if (!$config->cleanURL) {
 
-      // construct link
-      $link = trailingslashit( $base_url ) . '?' . implode('&', $queryParts);
+        // construct query parts
+        $queryParts = array();
+        $queryParts[] = 'page=CiviCRM';
+        if (isset($args['q'])) {
+          $queryParts[] = 'q=' . $args['q'];
+        }
+        if (isset($query)) {
+          $queryParts[] = $query;
+        }
+
+        // construct link
+        $link = trailingslashit( $base_url ) . '?' . implode('&', $queryParts);
+
+      }
+      else {
+
+        // clean URLs
+        if (isset($args['q'])) {
+          $base_url = trailingslashit( $base_url ) . str_replace('civicrm/', '', $args['q']) . '/';
+        }
+        if (isset($query)) {
+          $queryParts[] = $query;
+        }
+        $link = $base_url . '?' . implode('&', $queryParts);
+
+      }
 
       // add a class for styling purposes
       $class = ' civicrm-shortcode-multiple';
@@ -608,7 +626,6 @@ class CiviCRM_For_WordPress_Shortcodes {
 
           case 'info':
             $args['q'] = 'civicrm/event/info';
-            $_REQUEST['page'] = $_GET['page'] = 'CiviCRM';
             break;
 
           default:

--- a/includes/civicrm.users.php
+++ b/includes/civicrm.users.php
@@ -65,14 +65,14 @@ class CiviCRM_For_WordPress_Users {
 
 
   /**
-   * Register hooks to handle CiviCRM in a WordPress wpBasePage context
+   * Register hooks for handling users.
    *
    * @return void
    */
   public function register_hooks() {
 
     // add CiviCRM access capabilities to WordPress roles
-    add_action( 'init', array( $this, 'set_access_capabilities' ) );
+    $this->set_access_capabilities();
 
     // do not hook into user updates if Civi not installed yet
     if ( ! CIVICRM_INSTALLED ) return;


### PR DESCRIPTION
This is one part of the required changes to implement Clean URLs (or at least parity with CiviCRM's URL schema in Drupal) in WordPress. Please refer to the Jira issue for accompanying changes to CiviCRM Core - or [visit the PR directly](https://github.com/civicrm/civicrm-core/pull/11708) since Jira doesn't seem to have picked it up.

Please note that I do not recommend this as a production-ready PR. I think there's going to be a lot of testing required since there are so many moving parts to this. Any takers? :-)

---

 * [CRM-21788: Clean URLs in WordPress](https://issues.civicrm.org/jira/browse/CRM-21788)