### PR TITLE
CRM-21812 - don't specify installation type post install

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -308,7 +308,9 @@ class CiviCRM_For_WordPress {
     if ( $this->civicrm_in_wordpress() ) {
       // this is required for AJAX calls in WordPress admin
       $_GET['noheader'] = TRUE;
-    } else {
+    }
+
+    if ( !CIVICRM_INSTALLED && !$this->civicrm_in_wordpress() ) {
       $_GET['civicrm_install_type'] = 'wordpress';
     }
 


### PR DESCRIPTION
The wp-cli-login-server plugin checks for the presence of elements in the $_GET array, and fails if any are found.  This conflicts with CiviCRM, which places:

```
$_GET['civicrm_install_type'] = 'wordpress';
```

into every page load.

I confirmed that this value is only used for install, and placed a conditional around it to only insert pre-install.  I successfully installed CiviCRM and engaged in normal use with the conditional applied, and confirmed that this fixed the WP plugin.

This is intended to close https://github.com/aaemnnosttv/wp-cli-login-command/issues/24.

---

 * [CRM-21812: WordPress install variable causes conflict with some WP plugins](https://issues.civicrm.org/jira/browse/CRM-21812)