### PR TITLE
add GitHub PR template and Contributing templates to WP repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+CiviCRM is a community-driven open-source project. It has a small, full-time 
+[core team](https://civicrm.org/core-team)
+which facilitates development and works on critical issues. 
+Additionally, a large community of active contributors and 
+[partner organizations](https://civicrm.org/partners-contributors)
+drive much of the development work. 
+
+For developers, CiviCRM maintains a comprehensive
+[Developer Guide](https://docs.civicrm.org/dev/en/latest).
+Topics of particular importance while submitting pull requests include:
+
+* [Contributing to CiviCRM core](https://docs.civicrm.org/dev/en/latest/core/contributing/)
+* [Pull requests](https://docs.civicrm.org/dev/en/latest/tools/git/#pr)
+* [Git workflow overview](https://docs.civicrm.org/dev/en/latest/tools/git/#contributing)
+* [Writing automated tests](https://docs.civicrm.org/dev/en/latest/testing/setup/)
+* [Jenkins continuous integration](https://docs.civicrm.org/dev/en/latest/tools/jenkins/)
+* [Release Process](https://docs.civicrm.org/dev/en/latest/core/release-process/)
+* [Developer Community](https://docs.civicrm.org/dev/en/latest/basics/community/)
+
+CiviCRM thanks you for your contributions and invites you to [log your time spent](https://civicrm.org/contributor-log) so that you (or your organization) may receive public recognition and promotion for your efforts.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+Overview
+----------------------------------------
+_A brief description of the pull request. Try to keep it non-technical._
+
+Before
+----------------------------------------
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+After
+----------------------------------------
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+Technical Details
+----------------------------------------
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+Comments
+----------------------------------------
+_Anything else you would like the reviewer to note_


### PR DESCRIPTION
Overview
----------------------------------------
Add GitHub templates for Pull requests and Contributing

Before
----------------------------------------
Pull Requests were unstructured.   Contributing documnetation was only in the civicrm-core repo

After
----------------------------------------
Pull requests will ask for details in the civicrm-wordpress repo matching civicrm-core.   This will hopefully lead to more details on the initial PR.  This will be especially important if the PR is not linked to an issue.

Technical Details
----------------------------------------
None

Comments
----------------------------------------
