### PR TITLE
Revert "Gutenberg Compatibility - Do not render shortcodes in REST context"

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -246,11 +246,7 @@ class CiviCRM_For_WordPress_Shortcodes {
    * @return string HTML for output
    */
   public function render_single( $atts ) {
-    // Do not parse shortcodes in REST context, which breaks saving in Gutenberg editor
-    if(defined('REST_REQUEST') && REST_REQUEST){
-        return;
-    }
-   
+
     // check if we've already parsed this shortcode
     global $post;
     if ( is_object($post) ) {


### PR DESCRIPTION
Reverts civicrm/civicrm-wordpress#126

This was merged at the last minute, but it's not really a *regression*, and the merits are being reconsidered.