### PR TITLE
Gutenberg Compatibility - Do not render shortcodes in REST context

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -246,7 +246,11 @@ class CiviCRM_For_WordPress_Shortcodes {
    * @return string HTML for output
    */
   public function render_single( $atts ) {
-
+    // Do not parse shortcodes in REST context, which breaks saving in Gutenberg editor
+    if(defined('REST_REQUEST') && REST_REQUEST){
+        return;
+    }
+   
     // check if we've already parsed this shortcode
     global $post;
     if ( is_object($post) ) {


### PR DESCRIPTION
Overview
----------------------------------------
This prevents hard errors in Gutenberg by disabling short-code rendering in any REST calls.

See also: https://lab.civicrm.org/dev/wordpress/issues/1

This PR is a resubmission of @bastienho's #126, which was reverted to give more time for consideration.