### PR TITLE
Do not render shortcodes in PUT, POST or DELETE

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -241,6 +241,16 @@ class CiviCRM_For_WordPress_Shortcodes {
    * @return string HTML for output
    */
   public function render_single( $atts ) {
+    // Do not parse shortcodes in REST context for PUT, POST and DELETE methods
+    if(defined('REST_REQUEST') && REST_REQUEST && (isset($_PUT) || isset($_POST) || isset($_DELETE)) ){
+        // Return the original shortcode
+        $shortcode = '[civicrm';
+        foreach($atts as $att=>$val){
+            $shortcode.=' '.$att.'="'.$val.'"';
+        }
+        $shortcode.=']';
+        return $shortcode;
+    }
 
     // check if we've already parsed this shortcode
     global $post;


### PR DESCRIPTION
Overview
----------------------------------------
A correction for #129 
Do not render shortcodes in REST context for PUT, POST and DELETE methods

Before
----------------------------------------
**REST** calls _(eg: in gutenberg editor)_ using **PUT**, **POST** or **DELETE** methods are resulting on an exception. 

After
----------------------------------------
Shortcode is returned unrendered, as it.

Technical details
----------------------------------------
The exception is provided by CRM_Core_Controller

Comments
----------------------------------------
WordPress REST API output contain both rendered and raw content, so it seems to be cleaner to render the shortcode.

It would be nicer to update CiviCRM core in order to hook into `CRM_Core_Controller` to let adding `page_arguments[ignoreKey]=true` in request args.

Forcing ignoreKey to true correctly renders the shortcode. 


