### PR TITLE
[WIP][DO NOT MERGE] Allowed user defined shortcodes to be rendered

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -649,9 +649,14 @@ class CiviCRM_For_WordPress_Shortcodes {
         break;
 
       default:
-
-        echo '<p>' . __( 'Do not know how to handle this shortcode', 'civicrm' ) . '</p>';
-        return;
+        $args = apply_filters( 'civicrm_shortcode_preprocess_atts', $args, $shortcode_atts );
+        if (!$args) {
+          echo '<p>' . __( 'Do not know how to handle this shortcode', 'civicrm' ) . '</p>';
+          return;
+        }
+        else {
+          break;
+        }
 
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR will add support to render user defined shortcodes in WordPress when specified through extensions.

Before
----------------------------------------
Code returns abruptly with an error saying "Do not know how to handle this shortcode"

After
----------------------------------------
Code renders the shortcode based on filters specified in the extension.

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
