### PR TITLE
Modify PHP 7.2-incompatible statement in wp-cli

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -1096,7 +1096,7 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
                 $parsed['dbsyntax'] = $str;
             }
 
-            if (!count($dsn)) {
+            if (empty($dsn)) {
                 return $parsed;
             }
 


### PR DESCRIPTION
Overview
----------------------------------------
You can no longer use `count()` on non-countable variables in PHP 7.2.  This modifies the `parseDSN()` function similarly to how Seamus did in https://github.com/civicrm/civicrm-packages/pull/207.

Before
----------------------------------------
Running wp-cli in PHP 7.2 gets this error:

```
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /home/jon/local/example/htdocs/wp-content/plugins/civicrm/wp-cli/civicrm.php on line 1147
PHP Stack trace:
PHP   1. {main}() /usr/local/bin/wp-cli:0
PHP   2. include() /usr/local/bin/wp-cli:4
PHP   3. include() phar:///usr/local/bin/wp-cli/php/boot-phar.php:8
PHP   4. WP_CLI\bootstrap() phar:///usr/local/bin/wp-cli/php/wp-cli.php:23
PHP   5. WP_CLI\Bootstrap\LaunchRunner->process() phar:///usr/local/bin/wp-cli/php/bootstrap.php:75
PHP   6. WP_CLI\Runner->start() phar:///usr/local/bin/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23
PHP   7. WP_CLI\Runner->_run_command_and_exit() phar:///usr/local/bin/wp-cli/php/WP_CLI/Runner.php:1102
PHP   8. WP_CLI\Runner->run_command() phar:///usr/local/bin/wp-cli/php/WP_CLI/Runner.php:376
PHP   9. WP_CLI\Dispatcher\Subcommand->invoke() phar:///usr/local/bin/wp-cli/php/WP_CLI/Runner.php:353
PHP  10. call_user_func:{phar:///usr/local/bin/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:425}() phar:///usr/local/bin/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:425
PHP  11. WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}() phar:///usr/local/bin/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:425
PHP  12. call_user_func:{phar:///usr/local/bin/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:89}() phar:///usr/local/bin/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:89
PHP  13. CiviCRM_Command->__invoke() phar:///usr/local/bin/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:89
PHP  14. CiviCRM_Command->sqlDump() /home/jon/local/example/htdocs/wp-content/plugins/civicrm/wp-cli/civicrm.php:169
PHP  15. CiviCRM_Command::parseDSN() /home/jon/local/example/htdocs/wp-content/plugins/civicrm/wp-cli/civicrm.php:781
```

After
----------------------------------------
wp-cli works similarly to PHP < 7.2.
