### PR TITLE
Allow user-defined shortcode components to be rendered

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -280,6 +280,11 @@ class CiviCRM_For_WordPress_Shortcodes {
     // preprocess shortcode attributes
     $args = $this->preprocess_atts( $atts );
 
+    // sanity check for improperly constructed shortcode
+    if ( $args === FALSE ) {
+      return '<p>' . __( 'Do not know how to handle this shortcode.', 'civicrm' ) . '</p>';
+    }
+
     // invoke() requires environment variables to be set
     foreach ( $args as $key => $value ) {
       if ( $value !== NULL ) {
@@ -324,6 +329,11 @@ class CiviCRM_For_WordPress_Shortcodes {
 
     // pre-process shortcode and retrieve args
     $args = $this->preprocess_atts( $atts );
+
+    // sanity check for improperly constructed shortcode
+    if ( $args === FALSE ) {
+      return '<p>' . __( 'Do not know how to handle this shortcode.', 'civicrm' ) . '</p>';
+    }
 
     // get data for this shortcode
     $data = $this->get_data( $atts, $args );
@@ -596,6 +606,7 @@ class CiviCRM_For_WordPress_Shortcodes {
       'force' => $force,
     );
 
+    // construct args for known components
     switch ( $component ) {
 
       case 'contribution':
@@ -622,8 +633,7 @@ class CiviCRM_For_WordPress_Shortcodes {
             break;
 
           default:
-            echo '<p>' . __( 'Do not know how to handle this shortcode', 'civicrm' ) . '</p>';
-            return;
+            return FALSE;
         }
         break;
 
@@ -658,11 +668,6 @@ class CiviCRM_For_WordPress_Shortcodes {
         unset($args['id']);
         break;
 
-      default:
-
-        echo '<p>' . __( 'Do not know how to handle this shortcode', 'civicrm' ) . '</p>';
-        return;
-
     }
 
     /**
@@ -676,7 +681,14 @@ class CiviCRM_For_WordPress_Shortcodes {
      * @param array $shortcode_atts Shortcode attributes
      * @return array $args Modified shortcode arguments
      */
-    return apply_filters( 'civicrm_shortcode_preprocess_atts', $args, $shortcode_atts );
+    $args = apply_filters( 'civicrm_shortcode_preprocess_atts', $args, $shortcode_atts );
+
+    // sanity check for path
+    if ( ! isset( $args['q'] ) ) {
+      return FALSE;
+    }
+
+    return $args;
 
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Completes the work begun in #131 

Before
----------------------------------------
WordPress plugins and CiviCRM Extensions which defined custom components for the `[civicrm]` shortcode found that the shortcode was not rendered.

After
----------------------------------------
Allow custom components to be defined for the `[civicrm]` shortcode and for those shortcodes to be rendered.

Technical Details
----------------------------------------
WordPress plugins and CiviCRM Extensions will need to use the `civicrm_shortcode_preprocess_atts` and `civicrm_shortcode_get_data` filters to add their component to the `[civicrm]` shortcode.

For example, consider the following bare-bones shortcode `[civicrm component="my-component"]`. We can extend the CiviCRM shortcode like this:

```php
if ( function_exists( 'add_filter' ) ) {
	add_filter( 'civicrm_shortcode_preprocess_atts', 'extensionprefix_amend_args', 10, 2 );
	add_filter( 'civicrm_shortcode_get_data', 'extensionprefix_amend_data', 10, 3 );
}

/**
 * Filter the CiviCRM shortcode arguments.
 *
 * Add our component and a CiviCRM path.
 *
 * @param array $args Existing shortcode arguments.
 * @param array $shortcode_atts Shortcode attributes.
 * @return array $args Modified shortcode arguments.
 */
function extensionprefix_amend_args( $args, $shortcode_atts ) {

	// pass through if not our component
	if ( $shortcode_atts['component'] !== 'my-component' ) {
		return $args;
	}

	// add our custom component
	$args['component'] = 'my-component';

	// add a component path
	$args['q'] = 'civicrm/my-component/foo';

	return $args;

}

/**
 * Filter the CiviCRM shortcode data array.
 *
 * Let's add some arbitrary text to the pre-rendered shortcode's description to
 * indicate that this extension has something to say.
 *
 * @param array $data Existing shortcode data
 * @param array $atts Shortcode attributes array
 * @param array $args Shortcode arguments array
 * @return array $data Modified shortcode data
 */
function extensionprefix_amend_data( $data, $atts, $args ) {

	// pass through if not our component
	if ( $args['component'] !== 'my-component' ) {
		return $args;
	}

	// add some arbitrary text to pre-rendered shortcode
	$data['text'] = ts('Hello from My Component!');

	return $data;

}
```

This produces the following when the shortcode is rendered:

<img width="609" alt="screen shot 2018-09-25 at 13 35 22" src="https://user-images.githubusercontent.com/726936/46014648-ea7ebf00-c0c7-11e8-94fa-fd163a200a75.png">

Comments
----------------------------------------
Related #112 