### PR TITLE
Do not start session when running under WP-CLI

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -301,7 +301,8 @@ class CiviCRM_For_WordPress {
     $this->civicrm_in_wordpress_set();
 
     // there is no session handling in WP hence we start it for CiviCRM pages
-    if (!session_id()) {
+    // except when running via WP-CLI which does not require sessions
+    if ( empty( session_id() ) && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
       session_start();
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Prevents PHP warnings by skipping `session_start()` when running via WP-CLI.

Before
----------------------------------------
When running WP-CLI, there are situations where the Apache user has permissions that the Shell user does not, which can result in the following warnings:

```sh
$ wp plugin update civicrm-admin-utilities
PHP Warning:  session_start(): open(xxx.xx.xxx.xx:11211/sess_ncos60tkmhud8phq94hjco6as4, O_RDWR) failed: No such file or directory (2) in /path/to/wp-content/plugins/civicrm/civicrm.php on line 305
Warning: session_start(): open(xxx.xx.xxx.xx:11211/sess_ncos60tkmhud8phq94hjco6as4, O_RDWR) failed: No such file or directory (2) in /path/to/wp-content/plugins/civicrm/civicrm.php on line 305
Success: Plugin already updated.
PHP Warning:  Unknown: open(xxx.xx.xxx.xx:11211/sess_ncos60tkmhud8phq94hjco6as4, O_RDWR) failed: No such file or directory (2) in Unknown on line 0
Warning: Unknown: open(xxx.xx.xxx.xx:11211/sess_ncos60tkmhud8phq94hjco6as4, O_RDWR) failed: No such file or directory (2) in Unknown on line 0
PHP Warning:  Unknown: Failed to write session data (files). Please verify that the current setting of session.save_path is correct (xxx.xx.xxx.xx:11211) in Unknown on line 0
Warning: Unknown: Failed to write session data (files). Please verify that the current setting of session.save_path is correct (xxx.xx.xxx.xx:11211) in Unknown on line 0
```

Please note that the above is in the context of CiviCRM running via Memcached, but the ability to write to `session.save_path` is common to all contexts.

After
----------------------------------------
No PHP warnings:

```sh
$ wp plugin update civicrm-admin-utilities
Success: Plugin already updated.
```

Technical Details
----------------------------------------
Tests for WP-CLI and skips `session_start()` when detected.