### PR TITLE
Update profile shortcode to use new front-end title

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -793,7 +793,11 @@ class CiviCRM_For_WordPress_Shortcodes {
         $civi_entity = civicrm_api( 'uf_group', 'getsingle', $params );
 
         // set title
-        $data['title'] = $civi_entity['title'];
+        if ( isset($civi_entity['frontend_title']) ) {
+          $data['title'] = $civi_entity['frontend_title'];
+        } else {
+          $data['title'] = $civi_entity['title'];
+        }
 
         // set text to empty
         $data['text'] = '';


### PR DESCRIPTION
Overview
----------------------------------------
Civi profiles have a new option to show a different title on the front end. This updates the shortcode to use this title if it's available.

Before
----------------------------------------
Profile uses the title field.

After
----------------------------------------
Profile uses frontend_title field if available, and falls back to title if not.
