### PR TITLE
Fix fatal error with some versions of PHP

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -335,11 +335,14 @@ class CiviCRM_For_WordPress {
       wp_die( __( 'Only one instance of CiviCRM_For_WordPress please', 'civicrm' ) );
     }
 
+    // Get existing session ID
+    $session_id = session_id();
+
     /*
      * There is no session handling in WP - hence we start it for CiviCRM pages
      * except when running via WP-CLI which does not require sessions.
      */
-    if ( empty( session_id() ) && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+    if ( empty( $session_id ) && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
       session_start();
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Simple fix to prevent fatal error with some versions of PHP. Fixes [Issue 16](https://lab.civicrm.org/dev/wordpress/issues/16).

Before
----------------------------------------
Some users report

```
Fatal error: Can't use function return value in write context in .../public_html/CRM/wp-content/plugins/civicrm/civicrm.php on line 342
```

After
----------------------------------------
Should not throw fatal error.