### PR TITLE
Cleaner front-end URLs

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -610,25 +610,29 @@ class CiviCRM_For_WordPress {
     // Register user hooks
     $this->users->register_hooks();
 
-    // Have we flushed rewrite rules?
-    if ( get_option( 'civicrm_rules_flushed' ) !== 'true' ) {
+    // If CiviCRM is installed, we can use clean URLs.
+    if ( CIVICRM_INSTALLED ) {
 
-      // Apply custom rewrite rules, then flush rules afterwards
-      $this->rewrite_rules( true );
+      // Have we flushed rewrite rules?
+      if ( get_option( 'civicrm_rules_flushed' ) !== 'true' ) {
 
-      // Set a one-time-only option to flag that this has been done
-      add_option( 'civicrm_rules_flushed', 'true' );
+        // Apply custom rewrite rules, then flush rules afterwards
+        $this->rewrite_rules( true );
 
-    } else {
+        // Set a one-time-only option to flag that this has been done
+        add_option( 'civicrm_rules_flushed', 'true' );
 
-      // Apply custom rewrite rules normally
-      $this->rewrite_rules();
+      } else {
+
+        // Apply custom rewrite rules normally
+        $this->rewrite_rules();
+
+      }
+
+      // Add our query vars
+      add_filter( 'query_vars', array( $this, 'query_vars' ) );
 
     }
-
-    // Add our query vars
-    add_filter( 'query_vars', array( $this, 'query_vars' ) );
-
 
   }
 

--- a/civicrm.php
+++ b/civicrm.php
@@ -607,32 +607,55 @@ class CiviCRM_For_WordPress {
    */
   public function register_hooks_common() {
 
-    // Register user hooks
+    // Register user hooks.
     $this->users->register_hooks();
 
-    // If CiviCRM is installed, we can use clean URLs.
-    if ( CIVICRM_INSTALLED ) {
+    // Register hooks for clean URLs.
+    $this->register_hooks_clean_urls();
 
-      // Have we flushed rewrite rules?
-      if ( get_option( 'civicrm_rules_flushed' ) !== 'true' ) {
+  }
 
-        // Apply custom rewrite rules, then flush rules afterwards
-        $this->rewrite_rules( true );
 
-        // Set a one-time-only option to flag that this has been done
-        add_option( 'civicrm_rules_flushed', 'true' );
+  /**
+   * Register hooks to handle Clean URLs.
+   *
+   * @since 5.12
+   */
+  public function register_hooks_clean_urls() {
 
-      } else {
+    // Bail if CiviCRM is not installed.
+    if (!CIVICRM_INSTALLED) {
+      return;
+    }
 
-        // Apply custom rewrite rules normally
-        $this->rewrite_rules();
+    // Bail if we can't initialize CiviCRM.
+    if (!$this->initialize()) {
+      return;
+    }
 
-      }
+    // Bail if CiviCRM is not using clean URLs.
+    if (!defined('CIVICRM_CLEANURL') || CIVICRM_CLEANURL !== 1) {
+      return;
+    }
 
-      // Add our query vars
-      add_filter( 'query_vars', array( $this, 'query_vars' ) );
+    // Have we flushed rewrite rules?
+    if ( get_option( 'civicrm_rules_flushed' ) !== 'true' ) {
+
+      // Apply custom rewrite rules, then flush rules afterwards.
+      $this->rewrite_rules( true );
+
+      // Set a one-time-only option to flag that this has been done.
+      add_option( 'civicrm_rules_flushed', 'true' );
+
+    } else {
+
+      // Apply custom rewrite rules normally.
+      $this->rewrite_rules();
 
     }
+
+    // Add our query vars.
+    add_filter( 'query_vars', array( $this, 'query_vars' ) );
 
   }
 

--- a/civicrm.php
+++ b/civicrm.php
@@ -675,11 +675,6 @@ class CiviCRM_For_WordPress {
    */
   public function rewrite_rules( $flush_rewrite_rules = false ) {
 
-    // Kick out if admin
-    if (is_admin()) {
-      return;
-    }
-
     // Kick out if not CiviCRM
     if (!$this->initialize()) {
       return;

--- a/civicrm.php
+++ b/civicrm.php
@@ -720,8 +720,8 @@ class CiviCRM_For_WordPress {
 
     // Let's add rewrite rule when viewing the basepage
     add_rewrite_rule(
-      '^' . $config->wpBasePage . '/([^/]*)/([^/]*)/?',
-      'index.php?page_id=' . $basepage->ID . '&page=CiviCRM&q=civicrm/$matches[1]/$matches[2]',
+      '^' . $config->wpBasePage . '/([^?]*)?',
+      'index.php?page_id=' . $basepage->ID . '&page=CiviCRM&q=civicrm%2F$matches[1]',
       'top'
     );
 

--- a/civicrm.php
+++ b/civicrm.php
@@ -384,8 +384,11 @@ class CiviCRM_For_WordPress {
    */
   public function civicrm_in_wordpress_set() {
 
+    // Get identifying query var
+    $page = get_query_var( 'page' );
+
     // Store
-    self::$in_wordpress = ( isset( $_GET['page'] ) && $_GET['page'] == 'CiviCRM' ) ? TRUE : FALSE;
+    self::$in_wordpress = ( $page == 'CiviCRM' ) ? TRUE : FALSE;
 
   }
 
@@ -607,6 +610,26 @@ class CiviCRM_For_WordPress {
     // Register user hooks
     $this->users->register_hooks();
 
+    // Have we flushed rewrite rules?
+    if ( get_option( 'civicrm_rules_flushed' ) !== 'true' ) {
+
+      // Apply custom rewrite rules, then flush rules afterwards
+      $this->rewrite_rules( true );
+
+      // Set a one-time-only option to flag that this has been done
+      add_option( 'civicrm_rules_flushed', 'true' );
+
+    } else {
+
+      // Apply custom rewrite rules normally
+      $this->rewrite_rules();
+
+    }
+
+    // Add our query vars
+    add_filter( 'query_vars', array( $this, 'query_vars' ) );
+
+
   }
 
 
@@ -639,6 +662,105 @@ class CiviCRM_For_WordPress {
 
     // Enable shortcode modal
     $this->modal->register_hooks();
+
+  }
+
+
+  /**
+   * Add our rewrite rules.
+   *
+   * @since 5.7
+   *
+   * @param bool $flush_rewrite_rules True if rules should be flushed, false otherwise.
+   */
+  public function rewrite_rules( $flush_rewrite_rules = false ) {
+
+    // Kick out if admin
+    if (is_admin()) {
+      return;
+    }
+
+    // Kick out if not CiviCRM
+    if (!$this->initialize()) {
+      return;
+    }
+
+    // Get config
+    $config = CRM_Core_Config::singleton();
+
+    // Get basepage object
+    $basepage = get_page_by_path( $config->wpBasePage );
+
+    // Sanity check
+    if (!is_object($basepage)) {
+        return;
+    }
+
+    // Let's add rewrite rule when viewing the basepage
+    add_rewrite_rule(
+      '^' . $config->wpBasePage . '/([^/]*)/([^/]*)/?',
+      'index.php?page_id=' . $basepage->ID . '&page=CiviCRM&q=civicrm/$matches[1]/$matches[2]',
+      'top'
+    );
+
+    // Maybe force flush
+    if ($flush_rewrite_rules) {
+      flush_rewrite_rules();
+    }
+
+    /**
+     * Broadcast the rewrite rules event.
+     *
+     * @since 5.7
+     *
+     * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
+     */
+    do_action( 'civicrm_after_rewrite_rules', $flush_rewrite_rules );
+
+  }
+
+
+  /**
+   * Add our query vars.
+   *
+   * @since 5.7
+   *
+   * @param array $query_vars The existing query vars.
+   * @return array $query_vars The modified query vars.
+   */
+  public function query_vars( $query_vars ) {
+
+    // Sanity check
+    if (!is_array($query_vars)) {
+      $query_vars = array();
+    }
+
+    // Build our query vars
+    $civicrm_query_vars = array(
+      'page', 'q', 'reset', 'id', 'html', 'snippet', // URL query vars
+      'action', 'mode', 'cid', 'gid', 'sid', 'cs', 'force', // Shortcode query vars
+    );
+
+    /**
+     * Filter the default CiviCRM query vars.
+     *
+     * Use in combination with `civicrm_query_vars_assigned` action to ensure
+     * that any other query vars are included in the assignment to the
+     * super-global arrays.
+     *
+     * @since 5.7
+     *
+     * @param array $civicrm_query_vars The default set of query vars.
+     * @return array $civicrm_query_vars The modified set of query vars.
+     */
+    $civicrm_query_vars = apply_filters( 'civicrm_query_vars', $civicrm_query_vars );
+
+    // Now add them to WordPress
+    foreach( $civicrm_query_vars as $civicrm_query_var ) {
+      $query_vars[] = $civicrm_query_var;
+    }
+
+    return $query_vars;
 
   }
 
@@ -970,7 +1092,7 @@ class CiviCRM_For_WordPress {
   public function admin_page_load() {
 
     // This is required for AJAX calls in WordPress admin
-    $_GET['noheader'] = TRUE;
+    $_REQUEST['noheader'] = $_GET['noheader'] = TRUE;
 
     // Add resources for back end
     $this->add_core_resources( FALSE );
@@ -1215,6 +1337,11 @@ class CiviCRM_For_WordPress {
      */
     $this->remove_wp_magic_quotes();
 
+    // Required for AJAX calls
+    if ($this->civicrm_in_wordpress()) {
+      $_REQUEST['noheader'] = $_GET['noheader'] = TRUE;
+    }
+
     // Code inside invoke() requires the current user to be set up
     $current_user = wp_get_current_user();
 
@@ -1233,9 +1360,9 @@ class CiviCRM_For_WordPress {
     $argdata = $this->get_request_args();
 
     // Set dashboard as default if args are empty
-   if ( !isset( $_GET['q'] ) ) {
-      $_GET['q']      = 'civicrm/dashboard';
-      $_GET['reset']  = 1;
+    if ( empty( $argdata['argString'] ) ) {
+      $_GET['q'] = 'civicrm/dashboard';
+      $_GET['reset'] = 1;
       $argdata['args'] = array('civicrm', 'dashboard');
     }
 
@@ -1264,11 +1391,11 @@ class CiviCRM_For_WordPress {
    * Non-destructively override WordPress magic quotes.
    *
    * Only called by invoke() to undo WordPress default behaviour.
-   * CMW: Should probably be a private method.
    *
    * @since 4.4
+   * @since 5.7 Rewritten to work with query vars.
    */
-  public function remove_wp_magic_quotes() {
+  private function remove_wp_magic_quotes() {
 
     // Save original arrays
     $this->wp_get     = $_GET;
@@ -1277,10 +1404,56 @@ class CiviCRM_For_WordPress {
     $this->wp_request = $_REQUEST;
 
     // Reassign globals
-    $_GET     = stripslashes_deep($_GET);
-    $_POST    = stripslashes_deep($_POST);
-    $_COOKIE  = stripslashes_deep($_COOKIE);
-    $_REQUEST = stripslashes_deep($_REQUEST);
+    $_GET     = stripslashes_deep( $_GET );
+    $_POST    = stripslashes_deep( $_POST );
+    $_COOKIE  = stripslashes_deep( $_COOKIE );
+    $_REQUEST = stripslashes_deep( $_REQUEST );
+
+    // Test for query var
+    $q = get_query_var( 'q' );
+    if (!empty($q)) {
+
+      $page = get_query_var( 'page' );
+      $reset = get_query_var( 'reset' );
+      $id = get_query_var( 'id' );
+      $html = get_query_var( 'html' );
+      $snippet = get_query_var( 'snippet' );
+
+      $action = get_query_var( 'action' );
+      $mode = get_query_var( 'mode' );
+      $cid = get_query_var( 'cid' );
+      $gid = get_query_var( 'gid' );
+      $sid = get_query_var( 'sid' );
+      $cs = get_query_var( 'cs' );
+      $force = get_query_var( 'force' );
+
+      $_REQUEST['q'] = $_GET['q'] = $q;
+      $_REQUEST['page'] = $_GET['page'] = 'CiviCRM';
+      if (!empty($reset)) { $_REQUEST['reset'] = $_GET['reset'] = $reset; }
+      if (!empty($id)) { $_REQUEST['id'] = $_GET['id'] = $id; }
+      if (!empty($html)) { $_REQUEST['html'] = $_GET['html'] = $html; }
+      if (!empty($snippet)) { $_REQUEST['snippet'] = $_GET['snippet'] = $snippet; }
+
+      if (!empty($action)) { $_REQUEST['action'] = $_GET['action'] = $action; }
+      if (!empty($mode)) { $_REQUEST['mode'] = $_GET['mode'] = $mode; }
+      if (!empty($cid)) { $_REQUEST['cid'] = $_GET['cid'] = $cid; }
+      if (!empty($gid)) { $_REQUEST['gid'] = $_GET['gid'] = $gid; }
+      if (!empty($sid)) { $_REQUEST['sid'] = $_GET['sid'] = $sid; }
+      if (!empty($cs)) { $_REQUEST['cs'] = $_GET['cs'] = $cs; }
+      if (!empty($force)) { $_REQUEST['force'] = $_GET['force'] = $force; }
+
+      /**
+       * Broadcast that CiviCRM query vars have been assigned.
+       *
+       * Use in combination with `civicrm_query_vars` filter to ensure that any
+       * other query vars are included in the assignment to the super-global
+       * arrays.
+       *
+       * @since 5.7
+       */
+      do_action( 'civicrm_query_vars_assigned' );
+
+    }
 
   }
 
@@ -1289,11 +1462,10 @@ class CiviCRM_For_WordPress {
    * Restore WordPress magic quotes.
    *
    * Only called by invoke() to redo WordPress default behaviour.
-   * CMW: Should probably be a private method.
    *
    * @since 4.4
    */
-  public function restore_wp_magic_quotes() {
+  private function restore_wp_magic_quotes() {
 
     // Restore original arrays
     $_GET     = $this->wp_get;
@@ -1313,13 +1485,22 @@ class CiviCRM_For_WordPress {
    */
   public function is_page_request() {
 
+    // Assume not a CiviCRM page
+    $return = FALSE;
+
     // Kick out if not CiviCRM
     if (!$this->initialize()) {
-      return;
+      return $return;
     }
 
     // Get args
     $argdata = $this->get_request_args();
+
+    // Grab query var
+    $html = get_query_var( 'html' );
+    if (empty($html)) {
+      $html = isset($_GET['html']) ? $_GET['html'] : '';
+    }
 
     /*
      * FIXME: It's not sustainable to hardcode a whitelist of all of non-HTML
@@ -1329,19 +1510,22 @@ class CiviCRM_For_WordPress {
     if (CRM_Utils_Array::value('HTTP_X_REQUESTED_WITH', $_SERVER) == 'XMLHttpRequest'
         || ($argdata['args'][0] == 'civicrm' && in_array($argdata['args'][1], array('ajax', 'file')) )
         || !empty($_REQUEST['snippet'])
-        || strpos($argdata['argString'], 'civicrm/event/ical') === 0 && empty($_GET['html'])
+        || strpos($argdata['argString'], 'civicrm/event/ical') === 0 && empty($html)
         || strpos($argdata['argString'], 'civicrm/contact/imagefile') === 0
     ) {
-      return FALSE;
+      $return = FALSE;
     }
     else {
-      return TRUE;
+      $return = TRUE;
     }
+
+    return $return;
+
   }
 
 
   /**
-   * Get arguments and request string from $_GET.
+   * Get arguments and request string from query vars.
    *
    * @since 4.6
    *
@@ -1351,8 +1535,15 @@ class CiviCRM_For_WordPress {
 
     $argString = NULL;
     $args = array();
-    if (isset( $_GET['q'])) {
-      $argString = trim($_GET['q']);
+
+    // Get path from query vars
+    $q = get_query_var( 'q' );
+    if (empty($q)) {
+      $q = isset($_GET['q']) ? $_GET['q'] : '';
+    }
+
+    if (!empty($q)) {
+      $argString = trim($q);
       $args = explode('/', $argString);
     }
     $args = array_pad($args, 2, '');
@@ -1363,6 +1554,7 @@ class CiviCRM_For_WordPress {
     );
 
   }
+
 
   /**
    * Add CiviCRM's title to the header's <title> tag.

--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -529,19 +529,34 @@ class CiviCRM_For_WordPress_Basepage {
    */
   public function basepage_canonical_url( $canonical ) {
 
-    /*
-     * It would be better to specify which params are okay to accept as the
-     * canonical URLs, but this will work for the time being.
-     */
-    if ( empty( $_GET['page'] )
-      || empty( $_GET['q'] )
-      || 'CiviCRM' !== $_GET['page'] ) {
-      return $canonical;
+    // Access Civi config object
+    $config = CRM_Core_Config::singleton();
+
+    // Retain old logic when not using clean URLs
+    if (!$config->cleanURL) {
+
+      /*
+       * It would be better to specify which params are okay to accept as the
+       * canonical URLs, but this will work for the time being.
+       */
+      if ( empty( $_GET['page'] )
+        || empty( $_GET['q'] )
+        || 'CiviCRM' !== $_GET['page'] ) {
+        return $canonical;
+      }
+      $path = $_GET['q'];
+      unset( $_GET['q'] );
+      unset( $_GET['page'] );
+      $query = http_build_query( $_GET );
+
     }
-    $path = $_GET['q'];
-    unset( $_GET['q'] );
-    unset( $_GET['page'] );
-    $query = http_build_query( $_GET );
+    else {
+
+      $argdata = $this->civi->get_request_args();
+      $path = $argdata['argString'];
+      $query = http_build_query( $_GET );
+
+    }
 
     // We should, however, build the URL the way that CiviCRM expects it to be
     // (rather than through some other funny base page).

--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -321,6 +321,7 @@ class CiviCRM_For_WordPress_Shortcodes {
     // invoke() requires environment variables to be set
     foreach ( $args as $key => $value ) {
       if ( $value !== NULL ) {
+        set_query_var($key, $value);
         $_REQUEST[$key] = $_GET[$key] = $value;
       }
     }
@@ -406,18 +407,37 @@ class CiviCRM_For_WordPress_Shortcodes {
       // $absolute, $frontend, $forceBackend
       $base_url = $this->civi->get_base_url(TRUE, FALSE, FALSE);
 
-      // Construct query parts
+      // Init query parts
       $queryParts = array();
-      $queryParts[] = 'page=CiviCRM';
-      if (isset($args['q'])) {
-        $queryParts[] = 'q=' . $args['q'];
-      }
-      if (isset($query)) {
-        $queryParts[] = $query;
-      }
 
-      // Construct link
-      $link = trailingslashit( $base_url ) . '?' . implode('&', $queryParts);
+      // When not using clean URLs
+      if (!$config->cleanURL) {
+
+        // Construct query parts
+        $queryParts[] = 'page=CiviCRM';
+        if (isset($args['q'])) {
+          $queryParts[] = 'q=' . $args['q'];
+        }
+        if (isset($query)) {
+          $queryParts[] = $query;
+        }
+
+        // Construct link
+        $link = trailingslashit( $base_url ) . '?' . implode('&', $queryParts);
+
+      }
+      else {
+
+        // Clean URLs
+        if (isset($args['q'])) {
+          $base_url = trailingslashit( $base_url ) . str_replace('civicrm/', '', $args['q']) . '/';
+        }
+        if (isset($query)) {
+          $queryParts[] = $query;
+        }
+        $link = $base_url . '?' . implode('&', $queryParts);
+
+      }
 
       // Add a class for styling purposes
       $class = ' civicrm-shortcode-multiple';
@@ -706,7 +726,6 @@ class CiviCRM_For_WordPress_Shortcodes {
 
           case 'info':
             $args['q'] = 'civicrm/event/info';
-            $_REQUEST['page'] = $_GET['page'] = 'CiviCRM';
             break;
 
           default:


### PR DESCRIPTION
Overview
----------------------------------------
This PR implements "Clean URLs" in WordPress. It should not be merged without extensive testing!

Before
----------------------------------------
Front-end URLs in WordPress are of the form:
`https://domain.tld/civicrm/?page=CiviCRM&q=civicrm/contribute/transact&reset=1&id=1`

After
----------------------------------------
Front-end URLs in WordPress have the same structure as those in Drupal, e.g.:
`https://domain.tld/civicrm/contribute/transact/?reset=1&id=1`

Technical Details
----------------------------------------
All dependencies from #123 have been merged, so this PR can be tested in isolation. You will have to make sure that your `civicrm.settings.php` contains something like the following code:

```php
if (!defined('CIVICRM_CLEANURL')) {
  // check for Drupal clean URLs
  if ( function_exists('variable_get') && variable_get('clean_url', '0') != '0') {
    define('CIVICRM_CLEANURL', 1 );
  }
  elseif ( function_exists('config_get') && config_get('system.core', 'clean_url') != 0) {
    define('CIVICRM_CLEANURL', 1 );
  }
  // check for WordPress clean URLs
  elseif( function_exists('get_option') && get_option('permalink_structure') != '' ) {
    define('CIVICRM_CLEANURL', 1);
  }
  else {
    define('CIVICRM_CLEANURL', 0);
  }
}
```

The key change is to set the `CIVICRM_CLEANURL` constant to `1`.

Comments
----------------------------------------
You may need to flush rewrite rules in WordPress for clean URLs to work. Visit the Permalinks settings page to trigger this.