### PR TITLE
Add editor config file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# CiviCRM-WordPress editor configuration normalization.
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# Unix-style newlines with a newline ending every file.
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Indentation.
+[*.php]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [Issue 11 (Code style)](https://lab.civicrm.org/dev/wordpress/issues/11) by adding a `.editorconfig` file to the repo.

Before
----------------------------------------
Editors that respect `.editorconfig` settings do not default to double-space-indented code.

After
----------------------------------------
Editors that respect `.editorconfig` settings do default to double-space-indented code.
