### PR TITLE
CMS path fix in wp-cli

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -165,6 +165,13 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
         return WP_CLI::error( "Unrecognized command - '$command'" );
       }
 
+      # if --path is set, save for later use by Civi
+      global $civicrm_paths;
+      $wp_cli_config = WP_CLI::get_config();
+      if (!empty($wp_cli_config['path'])) {
+        $civicrm_paths['cms.root']['path'] = $wp_cli_config['path'];
+      }
+
       # run command
       return $this->{$command_router[ $command ]}();
 


### PR DESCRIPTION
Overview
----------------------------------------
The path specified to wp-cli as `--path` is not passed to CiviCRM resulting in URL errors.

See dev/wordpress#18

Before
----------------------------------------
The path specified by `wp-cli --path` is not passed to CiviCRM.  One symptom of this is that mails delivered by `wp-cli --path XX --url http://XX api Job.execute` with click-through tracking enabled can have bad URL's.  

Steps to reproduce error:
- create a mailing including links, check 'click-through tracking' is enabled, submit mail
- from command line:
  - cd to somewhere _outside_ of the wp tree
  - run `wp-cli --user=cron --path=XX --url=http://YY api Job.execute auth=0`
- check mail - links don't work

After
----------------------------------------
The path specified by `wp-cli --path` is passed to CiviCRM.  Mails have correct trackable URL's


