### PR TITLE
Fix args when called via AJAX

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1566,8 +1566,8 @@ class CiviCRM_For_WordPress {
 
     // Fix 'civicrm/civicrm' elements derived from CRM:url()
     // @see https://lab.civicrm.org/dev/rc/issues/5#note_16205
-    if (stristr($q, 'civicrm/civicrm') !== false) {
-      $q = str_replace('civicrm/civicrm', 'civicrm', $q);
+    if (substr($q, 0, 16) === 'civicrm/civicrm/') {
+      $q = str_replace('civicrm/civicrm/', 'civicrm/', $q);
       $_REQUEST['q'] = $_GET['q'] = $q;
       set_query_var( 'q', $q );
     }

--- a/civicrm.php
+++ b/civicrm.php
@@ -1564,6 +1564,14 @@ class CiviCRM_For_WordPress {
       $q = isset($_GET['q']) ? $_GET['q'] : '';
     }
 
+    // Fix 'civicrm/civicrm' elements derived from CRM:url()
+    // @see https://lab.civicrm.org/dev/rc/issues/5#note_16205
+    if (stristr($q, 'civicrm/civicrm') !== false) {
+      $q = str_replace('civicrm/civicrm', 'civicrm', $q);
+      $_REQUEST['q'] = $_GET['q'] = $q;
+      set_query_var( 'q', $q );
+    }
+
     if (!empty($q)) {
       $argString = trim($q);
       $args = explode('/', $argString);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes AJAX requests when Clean URLs are enabled.

See: https://lab.civicrm.org/dev/rc/issues/5#note_16205

Before
----------------------------------------
CiviCRM's Javascript uses the `*path*` placeholder to construct AJAX URLs of the form:

```
https://domain.tld/civicrm/*path*/?*query*
```

This is made up of various component parts:

* Basepage: `https://domain.tld/civicrm/` (with the basepage slug set to the default `civicrm`)
* Path: `*path*` (in this case it's `civicrm/ajax/jqState` defined in `civicrm/civicrm/CRM/Core/Form.php`)
* Query: `*query*` (in this case it's `_value=1226` or equivalent ID)

The resulting URL is therefore:

```
https://domain.tld/civicrm/civicrm/ajax/jqState/?_value=1226
```

This URL, of course, is malformed as a front-end URL is not correctly parsed with the current logic, since the `q` variable is `civicrm/civicrm/ajax/jqState`.

After
----------------------------------------
URLs such as:

```
https://domain.tld/civicrm/civicrm/ajax/jqState/?_value=1226
```

are recognised and the resulting `q` variable (plus `$_GET['q']` and `$_REQUEST['q']`) is properly formatted such that the `q` variable becomes `civicrm/ajax/jqState`.

Comments
----------------------------------------
This is not an ideal fix (see my reply to https://lab.civicrm.org/dev/rc/issues/5#note_16205 for details) but it seems to successfully patch the problem for the time being.