### PR TITLE
Only check path when using Clean URLs

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1566,10 +1566,12 @@ class CiviCRM_For_WordPress {
 
     // Fix 'civicrm/civicrm' elements derived from CRM:url()
     // @see https://lab.civicrm.org/dev/rc/issues/5#note_16205
-    if (substr($q, 0, 16) === 'civicrm/civicrm/') {
-      $q = str_replace('civicrm/civicrm/', 'civicrm/', $q);
-      $_REQUEST['q'] = $_GET['q'] = $q;
-      set_query_var( 'q', $q );
+    if (defined('CIVICRM_CLEANURL') && CIVICRM_CLEANURL) {
+      if (substr($q, 0, 16) === 'civicrm/civicrm/') {
+        $q = str_replace('civicrm/civicrm/', 'civicrm/', $q);
+        $_REQUEST['q'] = $_GET['q'] = $q;
+        set_query_var( 'q', $q );
+      }
     }
 
     if (!empty($q)) {


### PR DESCRIPTION
Overview
----------------------------------------
Further to #150 and #151 and https://github.com/civicrm/civicrm-wordpress/pull/151#discussion_r278666038, this trivial change fixes Javascript-derived malformed paths only when `CIVICRM_CLEANURL` is defined and switched on.