### PR TITLE
dev/wordpress#30 revert how we get query var

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -384,11 +384,8 @@ class CiviCRM_For_WordPress {
    */
   public function civicrm_in_wordpress_set() {
 
-    // Get identifying query var
-    $page = get_query_var( 'page' );
-
     // Store
-    self::$in_wordpress = ( $page == 'CiviCRM' ) ? TRUE : FALSE;
+    self::$in_wordpress = (isset($_GET['page']) && $_GET['page'] == 'CiviCRM') ? TRUE : FALSE;
 
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
At the point where the WP function get_query_var(), the page vars may not have been loaded, causing Civi frontend pages to load with just the WP page content ("don't delete this page...").

Before
----------------------------------------
Civi frontend pages don't load properly.

After
----------------------------------------
Civi frontend pages load properly.

Technical Details
----------------------------------------
This changes uses the Civi Request class to retrieve the page var instead of get_query_var().