### PR TITLE
Recreate rewrite rules when basepage setting is updated

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -676,6 +676,9 @@ class CiviCRM_For_WordPress {
     // Print CiviCRM's header
     add_action('admin_head', array( $this, 'wp_head' ), 50);
 
+    // Listen for changes to the basepage setting
+    add_action( 'civicrm_postSave_civicrm_setting', array( $this, 'settings_change' ), 10 );
+
     // If settings file does not exist, show notice with link to installer
     if ( ! CIVICRM_INSTALLED ) {
       if ( isset( $_GET['page'] ) && $_GET['page'] == 'civicrm-install' ) {
@@ -689,6 +692,29 @@ class CiviCRM_For_WordPress {
 
     // Enable shortcode modal
     $this->modal->register_hooks();
+
+  }
+
+
+  /**
+   * Force rewrite rules to be recreated.
+   *
+   * When CiviCRM settings are saved, the method is called post-save. It checks
+   * if it's the WordPress Base Page setting that has been saved and causes all
+   * rewrite rules to be flushed on the next page load.
+   *
+   * @since 5.14
+   *
+   * @param obj $dao The CiviCRM database access object.
+   */
+  public function settings_change( $dao ) {
+
+    // Delete the option if conditions are met
+    if ( $dao instanceOf CRM_Core_DAO_Setting ) {
+      if ( isset( $dao->name ) && $dao->name == 'wpBasePage' ) {
+        delete_option( 'civicrm_rules_flushed' );
+      }
+    }
 
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When Clean URLs are enabled, it can sometimes be difficult to reliably flush the rewrite rules such that Clean URLs are applied. This PR causes those rules to be flushed when saving the WordPress Base Page setting in CiviCRM.

Before
----------------------------------------
Rewrite rules were not flushed when saving the WordPress Base Page setting in CiviCRM.

To reproduce:

1. Create a new WordPress page, for example `https://domain.org/my-new-basepage`
2. In CiviCRM, navigate to "Administer" / "System Settings" / "CMS Database Integration"
3. Change the base page slug to `my-new-basepage` and hit "Save"
4. Navigate to, for example, "Contributions" / "Manage Contribution Pages" and click "Links" / "Live Page" for one of the pages. The result will be a 404.

After
----------------------------------------
Rewrite rules are flushed when saving the WordPress Base Page setting in CiviCRM.

To test:

Same procedure as before, but this time, clicking the "Live Page" link shows the populated Contribution Page.