### PR TITLE
Add WP-oriented E2E test suite, with HookTest as an example

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+>
+  <testsuites>
+    <testsuite name="CiviCRM-WordPress Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./CiviWP</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/phpunit/CiviWP/HookTest.php
+++ b/tests/phpunit/CiviWP/HookTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace CiviWP {
+
+  use Civi\Test\EndToEndInterface;
+
+  /**
+   * Class HookTest
+   * @package CiviWP
+   * @group e2e
+   */
+  class HookTest extends \PHPUnit_Framework_TestCase implements EndToEndInterface {
+
+    public function testFoo() {
+      add_action('civicrm_fakeAlterableHook', 'onFakeAlterableHook', 10, 2);
+
+      $arg1 = 'hello';
+      $arg2 = array(
+        'foo' => 123,
+      );
+      $this->assertNotEquals($arg2['foo'], 456);
+      $this->assertNotEquals($arg2['hook_was_called'], 1);
+      \CRM_Utils_Hook::singleton()
+        ->invoke(
+          2,
+          $arg1,
+          $arg2,
+          \CRM_Utils_Hook::$_nullObject,
+          \CRM_Utils_Hook::$_nullObject,
+          \CRM_Utils_Hook::$_nullObject,
+          \CRM_Utils_Hook::$_nullObject,
+          'civicrm_fakeAlterableHook'
+        );
+
+      $this->assertEquals($arg2['foo'], 456);
+      $this->assertEquals($arg2['hook_was_called'], 1);
+    }
+
+  }
+
+}
+
+namespace {
+
+  function onFakeAlterableHook($arg1, &$arg2) {
+    if ($arg1 != 'hello') {
+      throw new \Exception("Failed to receive arg1");
+    }
+    if ($arg2['foo'] != 123) {
+      throw new \Exception("Failed to receive arg2[foo]");
+    }
+    $arg2['foo'] = 456;
+    $arg2['hook_was_called'] = 1;
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,55 @@
+<?php
+
+// We switch between a few different container configurations during testing.
+define('CIVICRM_CONTAINER_CACHE', 'never');
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+// phpcs:disable
+eval(cv('php:boot', 'phpcode'));
+// phpcs:enable
+assert("CIVICRM_UF === 'WordPress'");
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds an empty test suite with one example test.

Before
----------------------------------------
* There are no E2E tests specific to WordPress.

After
----------------------------------------
* There is one E2E test specific to WordPress. It checks that integration works between CiviCRM hooks and WP actions/filters.

Technical Details
----------------------------------------
To run this in a `civibuild` site:

```
$ cd build/wpmaster/wp-content/plugins/civicrm
$ phpunit5
```
