### PR TITLE
Fail more gracefully when upgrading on PHP 5.x  - 5.16 backport

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -832,6 +832,19 @@ class CiviCRM_For_WordPress {
   // CiviCRM Initialisation
   // ---------------------------------------------------------------------------
 
+  protected function assertPhpSupport() {
+    // Need to check this before bootstrapping - once we start bootstrapping, the error messages will become ugly.
+    if ( version_compare( PHP_VERSION, CIVICRM_WP_PHP_MINIMUM ) < 0 ) {
+      echo '<p>' .
+         sprintf(
+          __( 'CiviCRM requires PHP version %s or greater. You are running PHP version %s', 'civicrm' ),
+          CIVICRM_WP_PHP_MINIMUM,
+          PHP_VERSION
+         ) .
+         '<p>';
+      exit();
+    }
+  }
 
   /**
    * Initialize CiviCRM.
@@ -851,17 +864,7 @@ class CiviCRM_For_WordPress {
 
     if ( ! $initialized ) {
 
-      // Check for php version and ensure its greater than minPhpVersion
-      if ( version_compare( PHP_VERSION, CIVICRM_WP_PHP_MINIMUM ) < 0 ) {
-        echo '<p>' .
-           sprintf(
-            __( 'CiviCRM requires PHP version %s or greater. You are running PHP version %s', 'civicrm' ),
-            CIVICRM_WP_PHP_MINIMUM,
-            PHP_VERSION
-           ) .
-           '<p>';
-        exit();
-      }
+      $this->assertPhpSupport();
 
       // Check for settings
       if ( ! CIVICRM_INSTALLED ) {
@@ -1073,6 +1076,7 @@ class CiviCRM_For_WordPress {
    * @since 4.4
    */
   public function run_installer() {
+    $this->assertPhpSupport();
     $civicrmCore = CIVICRM_PLUGIN_DIR . 'civicrm';
 
     $setupPaths = array(

--- a/civicrm.php
+++ b/civicrm.php
@@ -87,6 +87,21 @@ if (!defined( 'CIVICRM_PLUGIN_DIR')) {
   define( 'CIVICRM_PLUGIN_DIR', plugin_dir_path(CIVICRM_PLUGIN_FILE) );
 }
 
+if ( !defined( 'CIVICRM_WP_PHP_MINIMUM' ) ) {
+  /**
+   * Minimum required PHP
+   *
+   * Note: This duplicates CRM_Upgrade_Form::MINIMUM_PHP_VERSION. The
+   * duplication helps avoid dependency issues. (Reading `Form::MINIMUM_PHP_VERSION`
+   * requires loading `civicrm.settings.php`, but that triggers a parse-error
+   * on PHP 5.x.)
+   *
+   * @see CRM_Upgrade_Form::MINIMUM_PHP_VERSION
+   * @see CiviWP\PhpVersionTest::testConstantMatch()
+   */
+  define( 'CIVICRM_WP_PHP_MINIMUM', '7.0.0' );
+}
+
 /*
  * The constant CIVICRM_SETTINGS_PATH is also defined in civicrm.config.php and
  * may already have been defined there - e.g. by cron or external scripts.
@@ -837,12 +852,11 @@ class CiviCRM_For_WordPress {
     if ( ! $initialized ) {
 
       // Check for php version and ensure its greater than minPhpVersion
-      $minPhpVersion = '5.3.4';
-      if ( version_compare( PHP_VERSION, $minPhpVersion ) < 0 ) {
+      if ( version_compare( PHP_VERSION, CIVICRM_WP_PHP_MINIMUM ) < 0 ) {
         echo '<p>' .
            sprintf(
-            __( 'CiviCRM requires PHP Version %s or greater. You are running PHP Version %s', 'civicrm' ),
-            $minPhpVersion,
+            __( 'CiviCRM requires PHP version %s or greater. You are running PHP version %s', 'civicrm' ),
+            CIVICRM_WP_PHP_MINIMUM,
             PHP_VERSION
            ) .
            '<p>';

--- a/tests/phpunit/CiviWP/PhpVersionTest.php
+++ b/tests/phpunit/CiviWP/PhpVersionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CiviWP;
+
+use Civi\Test\EndToEndInterface;
+
+class PhpVersionTest extends \PHPUnit_Framework_TestCase implements EndToEndInterface {
+
+  /**
+   * CIVICRM_WP_PHP_MINIMUM (civicrm.module) should match MINIMUM_PHP_VERSION (CRM/Upgrade/Form.php).
+   *
+   * The literal value should be duplicated in the define() to prevent dependency issues.
+   */
+  public function testConstantMatch() {
+    $constantFile = $this->getModulePath() . '/civicrm.php';
+    $this->assertFileExists($constantFile);
+    $content = file_get_contents($constantFile);
+    if (preg_match(";define\\(\\s*'CIVICRM_WP_PHP_MINIMUM'\\s*,\\s*'(.*)'\\s*\\);", $content, $m)) {
+      $this->assertEquals(\CRM_Upgrade_Form::MINIMUM_PHP_VERSION, $m[1]);
+    }
+    else {
+      $this->fail('Failed to find CIVICRM_WP_PHP_MINIMUM in ' . $constantFile);
+    }
+  }
+
+  /**
+   * @return string
+   *   Ex: '/var/www/wp-content/plugins/civicrm'
+   */
+  protected function getModulePath() {
+    return dirname(dirname(dirname(__DIR__)));
+  }
+
+}


### PR DESCRIPTION
Backport https://github.com/civicrm/civicrm-wordpress/pull/161

This version requirement officially went up to PHP 7.0 circa Civi 5.14. However, at that time, the upgrade metadata was kept at PHP 5.6 to allow somewhat softer landing for stragglers. That's no longer possible in Civi 5.16+,

This just gives a clearer error when someone tries to upgrade with PHP 5.x.