### PR TITLE
(NFC) assertPhpSupport - Code cleanup

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -832,8 +832,13 @@ class CiviCRM_For_WordPress {
   // CiviCRM Initialisation
   // ---------------------------------------------------------------------------
 
+  /**
+   * Check that the PHP version is supported. If not, raise a fatal error with a pointed message.
+   *
+   * One should check this before bootstrapping Civi - after we start the class-loader, the
+   * PHP-compatibility errors will become more ugly.
+   */
   protected function assertPhpSupport() {
-    // Need to check this before bootstrapping - once we start bootstrapping, the error messages will become ugly.
     if ( version_compare( PHP_VERSION, CIVICRM_WP_PHP_MINIMUM ) < 0 ) {
       echo '<p>' .
          sprintf(

--- a/civicrm.php
+++ b/civicrm.php
@@ -842,7 +842,7 @@ class CiviCRM_For_WordPress {
     if ( version_compare( PHP_VERSION, CIVICRM_WP_PHP_MINIMUM ) < 0 ) {
       echo '<p>' .
          sprintf(
-          __( 'CiviCRM requires PHP version %s or greater. You are running PHP version %s', 'civicrm' ),
+          __( 'CiviCRM requires PHP version %1$s or greater. You are running PHP version %2$s', 'civicrm' ),
           CIVICRM_WP_PHP_MINIMUM,
           PHP_VERSION
          ) .


### PR DESCRIPTION
This `assertPhpSupport()` was recently extracted. This cleans it up a bit more.

See https://github.com/civicrm/civicrm-wordpress/pull/162#issuecomment-523471741