### PR TITLE
redirect to setup page on activation /dev/wordpress/issues/37

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -310,7 +310,10 @@ class CiviCRM_For_WordPress {
 
     // Change option so this action never fires again
     update_option( 'civicrm_activation_in_progress', 'false' );
-
+    if (!isset($_GET['activate-multi'])) {
+      wp_redirect(admin_url("options-general.php?page=civicrm-install"));
+      exit;
+    }
   }
 
 

--- a/civicrm.php
+++ b/civicrm.php
@@ -310,7 +310,7 @@ class CiviCRM_For_WordPress {
 
     // Change option so this action never fires again
     update_option( 'civicrm_activation_in_progress', 'false' );
-    if (!isset($_GET['activate-multi'])) {
+    if ( ! is_multisite() && !isset($_GET['activate-multi'])) {
       wp_redirect(admin_url("options-general.php?page=civicrm-install"));
       exit;
     }


### PR DESCRIPTION
Signed-off-by: Kevin Cristiano <kcristiano@kcristiano.com>

Overview
----------------------------------------
It has become expected behavior for plugins that are more complex to redirect to their install or setup screen on activation.  This will redirect on activation but not on bulk activation

Before
----------------------------------------
Users have to click on the CiviCRM notice at the top of the site or in the sidebar

After
----------------------------------------
On activation redirect users to the install screen .  

Comments
----------------------------------------
https://lab.civicrm.org/dev/wordpress/issues/37
