### PR TITLE
Ensure front-end hooks are only registered on main query

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -559,8 +559,20 @@ class CiviCRM_For_WordPress {
    * Register hooks for the front end.
    *
    * @since 5.6
+   *
+   * @param WP_Query $query The WP_Query instance (passed by reference).
    */
-  public function register_hooks_front_end() {
+  public function register_hooks_front_end( $query ) {
+
+    // Bail if $query is not the main loop.
+    if ( ! $query->is_main_query() ) {
+      return;
+    }
+
+    // Bail if filters are suppressed on this query.
+    if ( true == $query->get( 'suppress_filters' ) ) {
+      return;
+    }
 
     // Prevent multiple calls
     static $alreadyRegistered = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
It has been reported that the Benevolent Pro theme makes a sub-query prior to the main query. This unsets the value of `get_query_var( 'page' )` and thus the CiviCRM basepage fails to render CiviCRM content. Given that other themes might do something similar, we should accommodate this sort of behaviour. The solution is to ensure that front-end hooks are only registered on main query.

See the issue on [Lab](https://lab.civicrm.org/dev/wordpress/issues/38) for further details.

Before
----------------------------------------
Making a sub-query prior to the main query unsets the value of `get_query_var( 'page' )` and CiviCRM content fails to render.

After
----------------------------------------
Making a sub-query prior to the main query no longer unsets the value of `get_query_var( 'page' )` and CiviCRM content renders as expected.

Steps to reproduce
----------------------------------------

Add this to a plugin or `functions.php` file:

```php
add_action( 'init', 'blah_init' );
function blah_init() {
	$args = array( 'posts_per_page' => 3 );
	$titles = [];
	$query = new WP_Query( $args );
	if ( $query->have_posts() ) {
		while ( $query->have_posts() ) {
			$query->the_post();
			$titles[] = get_the_title();
		}
		// Do something with titles.
	}
	wp_reset_postdata();
}
```

Boom.