### PR TITLE
Only redirect if CiviCRM is not already installed

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -310,7 +310,7 @@ class CiviCRM_For_WordPress {
 
     // Change option so this action never fires again
     update_option( 'civicrm_activation_in_progress', 'false' );
-    if ( ! is_multisite() && !isset($_GET['activate-multi'])) {
+    if ( ! is_multisite() && !isset($_GET['activate-multi']) && ! CIVICRM_INSTALLED ) {
       wp_redirect(admin_url("options-general.php?page=civicrm-install"));
       exit;
     }


### PR DESCRIPTION
Overview
----------------------------------------
If you install via CLI you will get redirected to setup page first time you go to CiviCRM in admin menu - fine if you did not do a CLI install `cv core:install` But if you did you get a you are not allowed to access this page message.

Need to add a check to see if `CIVICRM_INSTALLED` before doing the redirect.  This will also cover deactivating and reactivating for testing.

https://lab.civicrm.org/dev/rc/issues/9#note_26913

Before
----------------------------------------
If you activate civicrm from CLI and had done a cv install you would get redirected to a page you could not access.   If you deactivated CiviCRM (from cli or UI) and the activated you would also get the redirect

After
----------------------------------------
Only redirected if CiviCRM is not already installed


Comments
----------------------------------------
@christianwach  Do you see any additional improvements we can add?

Against RC as we should fix this before release