### PR TITLE
Set CMS Root in "civicrm_paths" more reliably

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -364,6 +364,15 @@ class CiviCRM_For_WordPress {
       session_start();
     }
 
+    /*
+     * AJAX calls do not set the 'cms.root' item, so make sure it is set here so
+     * the CiviCRM doesn't fall back on flaky directory traversal code.
+     */
+    global $civicrm_paths;
+    if (empty($civicrm_paths['cms.root']['path'])) {
+      $civicrm_paths['cms.root']['path'] = untrailingslashit(ABSPATH);
+    }
+
     // Get classes and instantiate
     $this->include_files();
 

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -165,13 +165,6 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
         return WP_CLI::error( "Unrecognized command - '$command'" );
       }
 
-      # if --path is set, save for later use by Civi
-      global $civicrm_paths;
-      $wp_cli_config = WP_CLI::get_config();
-      if (!empty($wp_cli_config['path'])) {
-        $civicrm_paths['cms.root']['path'] = $wp_cli_config['path'];
-      }
-
       # run command
       return $this->{$command_router[ $command ]}();
 
@@ -1330,5 +1323,17 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 
   WP_CLI::add_command( 'civicrm', 'CiviCRM_Command' );
   WP_CLI::add_command( 'cv', 'CiviCRM_Command' );
+
+  # Set path early.
+  WP_CLI::add_hook( 'before_wp_load', function() {
+
+    # if --path is set, save for later use by Civi
+    global $civicrm_paths;
+    $wp_cli_config = WP_CLI::get_config();
+    if (!empty($wp_cli_config['path'])) {
+      $civicrm_paths['cms.root']['path'] = $wp_cli_config['path'];
+    }
+
+  } );
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Builds on https://lab.civicrm.org/dev/core/issues/1412 to set `$civicrm_paths['cms.root']['path']` more reliably during the following requests:

* WP-CLI
* "Heartbeat" AJAX
* WordPress pseudo-cron

Before
----------------------------------------
`CRM_Utils_System_WordPress::cmsRootPath()` would be called without `$civicrm_paths['cms.root']['path']` being set for the above requests, causing the unreliable directory-traversal code to be run.

After
----------------------------------------
`CRM_Utils_System_WordPress::cmsRootPath()` runs with `$civicrm_paths['cms.root']['path']` being correctly set.