### PR TITLE
Fix basepage title for Yoast SEO when theme declares "title-tag" support

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -384,8 +384,14 @@ class CiviCRM_For_WordPress_Basepage {
     add_filter( 'wp_title', array( $this, 'wp_page_title' ), 100, 3 );
     add_filter( 'document_title_parts', array( $this, 'wp_page_title_parts' ), 100, 1 );
 
-    // Add compatibility with WordPress SEO plugin's Open Graph title
+    // Add compatibility with Yoast SEO plugin's Open Graph title
     add_filter( 'wpseo_opengraph_title', array( $this, 'wpseo_page_title' ), 100, 1 );
+
+    // Don't let the Yoast SEO plugin parse the basepage title
+    if ( class_exists( 'WPSEO_Frontend' ) ) {
+      $frontend = WPSEO_Frontend::get_instance();
+      remove_filter( 'pre_get_document_title', array( $frontend, 'title' ), 15 );
+    }
 
     // Include this content when base page is rendered
     add_filter( 'the_content', array( $this, 'basepage_render' ) );


### PR DESCRIPTION
As reported [on Mattermost](https://chat.civicrm.org/civicrm/pl/tjbhpekwmpdjmp7733irnwij5y) by Marcus J Wilson.

Overview
----------------------------------------
Fixes the basepage title when the Yoast SEO plugin is active and the theme declares "title-tag" support via `add_theme_support( 'title-tag' )`.

Before
----------------------------------------
The Yoast SEO plugin short-circuits the code in `wp_get_document_title()` by filtering via `pre_get_document_title`. This means that our code to apply the CiviCRM basepage title via the `document_title_parts` filter is never reached and the basepage title does not reflect the CiviCRM content.

After
----------------------------------------
The Yoast SEO plugin no longer parses the title and our code runs as expected.