### PR TITLE
Update to use the namespaced version of the PHPUnit test classes as t…

### DIFF
--- a/tests/phpunit/CiviWP/HookTest.php
+++ b/tests/phpunit/CiviWP/HookTest.php
@@ -9,7 +9,7 @@ namespace CiviWP {
    * @package CiviWP
    * @group e2e
    */
-  class HookTest extends \PHPUnit_Framework_TestCase implements EndToEndInterface {
+  class HookTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface {
 
     public function testFoo() {
       add_action('civicrm_fakeAlterableHook', 'onFakeAlterableHook', 10, 2);

--- a/tests/phpunit/CiviWP/PhpVersionTest.php
+++ b/tests/phpunit/CiviWP/PhpVersionTest.php
@@ -4,7 +4,7 @@ namespace CiviWP;
 
 use Civi\Test\EndToEndInterface;
 
-class PhpVersionTest extends \PHPUnit_Framework_TestCase implements EndToEndInterface {
+class PhpVersionTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface {
 
   /**
    * CIVICRM_WP_PHP_MINIMUM (civicrm.module) should match MINIMUM_PHP_VERSION (CRM/Upgrade/Form.php).


### PR DESCRIPTION
…his will work for phpunit6 going forward as well as phpunit5

Overview
----------------------------------------
This updates the class names to be their namespaced equivalents 

ping @kcristiano @totten 