### PR TITLE
Support polylang language prefixes with clean URLs

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -797,7 +797,19 @@ class CiviCRM_For_WordPress {
         return;
     }
 
-    // Let's add rewrite rule when viewing the basepage
+    // Let's add rewrite rule when viewing the basepage(s)
+    if ( function_exists( 'pll_languages_list' ) ) {
+      // Support polylang language prefixes - eg. ^(?:en/|pt/|)
+      $languages = pll_languages_list();
+      foreach ( $languages as $language ) {
+        $postID = pll_get_post( $basepage->ID, $language );
+        add_rewrite_rule(
+          "^{$language}/" . $config->wpBasePage . '/([^?]*)?',
+          'index.php?page_id=' . $postID . '&page=CiviCRM&q=civicrm%2F$matches[1]',
+          'top'
+        );
+      };
+    }
     add_rewrite_rule(
       '^' . $config->wpBasePage . '/([^?]*)?',
       'index.php?page_id=' . $basepage->ID . '&page=CiviCRM&q=civicrm%2F$matches[1]',


### PR DESCRIPTION
Overview
----------------------------------------
When using Wordpress in multilanguage with polylang you will most likely have URLs with a language prefix (eg. https://example.org/en/civicrm/...). Each language has it's own "post ID" matching the language so we have to have multiple civicrm base pages if we want CiviCRM to pick up the language.

Before
----------------------------------------
Clean URLS don't work in Wordpress with polylang

After
----------------------------------------
Clean URLs work in Wordpress with polylang. Language code is passed through to CiviCRM.

Technical Details
----------------------------------------
We create a rewrite rule for every enabled language - this means we can select the correct post ID for each language (which may be the "master" one or a language specific one).

Comments
----------------------------------------
Polylang allows various combinations of language prefixes, required or optional.  @christianwach Could you review - per our discussion.
