### PR TITLE
Make sure Rewrite Rules are flushed after creating the Base Page

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -300,6 +300,9 @@ class CiviCRM_For_WordPress_Basepage {
       restore_current_blog();
     }
 
+    // Make sure Rewrite Rules are flushed.
+    delete_option( 'civicrm_rules_flushed' );
+
     return $page_id;
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
Rewrite Rules have been defined and flushed prior to the creation of the Base Page resulting in 404s for CiviCRM pseudo-pages.

Before
----------------------------------------
404s on the Base Page.

After
----------------------------------------
Base Page content renders correctly.