### PR TITLE
Bump minimum install version to be 7.1 (Do not merge until 5.24 RC is cut)

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -83,7 +83,7 @@ if ( !defined( 'CIVICRM_WP_PHP_MINIMUM' ) ) {
    * @see CRM_Upgrade_Form::MINIMUM_PHP_VERSION
    * @see CiviWP\PhpVersionTest::testConstantMatch()
    */
-  define( 'CIVICRM_WP_PHP_MINIMUM', '7.0.0' );
+  define( 'CIVICRM_WP_PHP_MINIMUM', '7.1.0' );
 }
 
 /*


### PR DESCRIPTION
Overview
----------------------------------------
Bumps the minimum PHP version needed to be 7.1 

ping @totten @eileenmcnaughton 