### PR TITLE
Add shortcodes for Personal Campaign Pages

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -698,6 +698,14 @@ class CiviCRM_For_WordPress_Shortcodes {
         $args['q'] = 'civicrm/contribute/transact';
         break;
 
+      case 'pcp':
+
+        if ( $mode == 'preview' || $mode == 'test' ) {
+          $args['action'] = 'preview';
+        }
+        $args['q'] = 'civicrm/pcp/info';
+        break;
+
       case 'event':
 
         switch ( $action ) {
@@ -739,7 +747,6 @@ class CiviCRM_For_WordPress_Shortcodes {
         }
         $args['gid'] = $gid;
         break;
-
 
       case 'petition':
 


### PR DESCRIPTION
Overview
----------------------------------------
Requires https://github.com/civicrm/civicrm-core/pull/16695. This is the UI part that allows selecting Personal Campaign Pages when editing a page in wordpress.

Before
----------------------------------------
No personal campaign pages via shortcodes.

After
----------------------------------------
Personal campaign pages via shortcodes.

Technical Details
----------------------------------------


Comments
----------------------------------------
Ping @christianwach @kcristiano 