### PR TITLE
dev/core#1528: drop support for PHP 7.0

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -83,7 +83,7 @@ if ( !defined( 'CIVICRM_WP_PHP_MINIMUM' ) ) {
    * @see CRM_Upgrade_Form::MINIMUM_PHP_VERSION
    * @see CiviWP\PhpVersionTest::testConstantMatch()
    */
-  define( 'CIVICRM_WP_PHP_MINIMUM', '7.0.0' );
+  define( 'CIVICRM_WP_PHP_MINIMUM', '7.1.0' );
 }
 
 /*


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/16751 for the corresponding change in `civicrm-core`.

Before
----------------------------------------
CiviCRM installs and runs on PHP 7.0 and higher.

After
----------------------------------------
CIviCRM installs and runs on PHP 7.1 and higher.  Anyone on PHP 7.0 will not be able to upgrade or install.

Technical Details
----------------------------------------
This is different from how the other CMSes handle upgrades, since there's only one spot to set a minimum version.  Unlike on other CMSes where CiviCRM will upgrade and run, albeit with a big critical status message, with PHP 7.0 (per discussion on https://github.com/civicrm/civicrm-core/pull/16751), this will not be possible in WordPress.  The plugin will tell them to upgrade PHP and exit.