### PR TITLE
Set "cms.root" URL in addition to Path

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -368,6 +368,9 @@ class CiviCRM_For_WordPress {
     if (empty($civicrm_paths['cms.root']['path'])) {
       $civicrm_paths['cms.root']['path'] = untrailingslashit(ABSPATH);
     }
+    if (empty($civicrm_paths['cms.root']['url'])) {
+      $civicrm_paths['cms.root']['url'] = home_url();
+    }
 
     // Get classes and instantiate
     $this->include_files();

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -1311,11 +1311,16 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
   # Set path early.
   WP_CLI::add_hook( 'before_wp_load', function() {
 
-    # if --path is set, save for later use by Civi
+    # If --path is set, save for later use by CiviCRM.
     global $civicrm_paths;
     $wp_cli_config = WP_CLI::get_config();
     if (!empty($wp_cli_config['path'])) {
       $civicrm_paths['cms.root']['path'] = $wp_cli_config['path'];
+    }
+
+    # If --url is set, save for later use by CiviCRM.
+    if (!empty($wp_cli_config['url'])) {
+      $civicrm_paths['cms.root']['url'] = $wp_cli_config['url'];
     }
 
   } );


### PR DESCRIPTION
Overview
----------------------------------------
The code in `Civi::Paths::getVariable()` does not ensure all attributes of a named variable are set, so partially setting the attributes of `cms.root` sometimes causes "Cannot resolve path using 'cms.root.url'" exceptions to be thrown. This is relatively obscure because it requires a particular WordPress Multisite setup to occur, but the effect is repeatable.

Before
----------------------------------------
"Cannot resolve path using 'cms.root.url'" exceptions are thrown. "Settings - Resource URLs" screen renders incorrectly in WordPress Multisite on a Subsite:

<img width="1440" alt="Screen Shot 2020-03-24 at 11 01 40" src="https://user-images.githubusercontent.com/726936/77418607-04818680-6dbf-11ea-92d9-37a214872c5f.png">

After
----------------------------------------
"Cannot resolve path using 'cms.root.url'" exceptions are not thrown. "Settings - Resource URLs" screen renders correctly in WordPress Multisite on a Subsite.

Technical Details
----------------------------------------
This PR is necessary because of an incomplete check for the existence of all attributes [in Paths.php](https://github.com/civicrm/civicrm-core/blob/c879543be97e2d851430db3f17afaf9f4a1d00fa/Civi/Core/Paths.php#L154). Having said that, it's still better to assign both attributes early than have `Civi::Paths::getVariable()` recalculate them later.