### PR TITLE
Remove "page=CiviCRM" query string from WordPress front-end (5.26)

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -419,8 +419,8 @@ class CiviCRM_For_WordPress {
    */
   public function civicrm_in_wordpress_set() {
 
-    // Get identifying query var
-    $page = get_query_var( 'page' );
+    // Get identifying query var.
+    $page = get_query_var( 'civiwp' );
 
     // Store
     self::$in_wordpress = ( $page == 'CiviCRM' ) ? TRUE : FALSE;
@@ -578,6 +578,9 @@ class CiviCRM_For_WordPress {
     // Go no further if CiviCRM not installed yet
     if ( ! CIVICRM_INSTALLED ) return;
 
+    // Add our query vars.
+    add_filter( 'query_vars', array( $this, 'query_vars' ) );
+
     // Delay everything else until query has been parsed
     add_action( 'parse_query', array( $this, 'register_hooks_front_end' ) );
 
@@ -609,6 +612,14 @@ class CiviCRM_For_WordPress {
       return;
     }
     $alreadyRegistered = TRUE;
+
+    // Redirect if old query var is present.
+    if ( 'CiviCRM' == get_query_var( 'page' ) && 'CiviCRM' != get_query_var( 'civiwp' ) ) {
+      $redirect_url = remove_query_arg( 'page', false );
+      $redirect_url = add_query_arg( 'civiwp', 'CiviCRM', $redirect_url );
+      wp_redirect( $redirect_url, 301 );
+      exit();
+    }
 
     // Store context
     $this->civicrm_in_wordpress_set();
@@ -720,9 +731,6 @@ class CiviCRM_For_WordPress {
 
     }
 
-    // Add our query vars.
-    add_filter( 'query_vars', array( $this, 'query_vars' ) );
-
   }
 
 
@@ -813,7 +821,7 @@ class CiviCRM_For_WordPress {
     // Let's add rewrite rule when viewing the basepage
     add_rewrite_rule(
       '^' . $config->wpBasePage . '/([^?]*)?',
-      'index.php?page_id=' . $basepage->ID . '&page=CiviCRM&q=civicrm%2F$matches[1]',
+      'index.php?page_id=' . $basepage->ID . '&civiwp=CiviCRM&q=civicrm%2F$matches[1]',
       'top'
     );
 
@@ -853,7 +861,7 @@ class CiviCRM_For_WordPress {
 
     // Build our query vars
     $civicrm_query_vars = array(
-      'page', 'q', 'reset', 'id', 'html', 'snippet', // URL query vars
+      'civiwp', 'q', 'reset', 'id', 'html', 'snippet', // URL query vars
       'action', 'mode', 'cid', 'gid', 'sid', 'cs', 'force', // Shortcode query vars
     );
 
@@ -1537,7 +1545,7 @@ class CiviCRM_For_WordPress {
     $q = get_query_var( 'q' );
     if (!empty($q)) {
 
-      $page = get_query_var( 'page' );
+      $page = get_query_var( 'civiwp' );
       $reset = get_query_var( 'reset' );
       $id = get_query_var( 'id' );
       $html = get_query_var( 'html' );
@@ -1552,7 +1560,7 @@ class CiviCRM_For_WordPress {
       $force = get_query_var( 'force' );
 
       $_REQUEST['q'] = $_GET['q'] = $q;
-      $_REQUEST['page'] = $_GET['page'] = 'CiviCRM';
+      $_REQUEST['civiwp'] = $_GET['civiwp'] = 'CiviCRM';
       if (!empty($reset)) { $_REQUEST['reset'] = $_GET['reset'] = $reset; }
       if (!empty($id)) { $_REQUEST['id'] = $_GET['id'] = $id; }
       if (!empty($html)) { $_REQUEST['html'] = $_GET['html'] = $html; }

--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -558,14 +558,14 @@ class CiviCRM_For_WordPress_Basepage {
        * It would be better to specify which params are okay to accept as the
        * canonical URLs, but this will work for the time being.
        */
-      if ( empty( $_GET['page'] )
+      if ( empty( $_GET['civiwp'] )
         || empty( $_GET['q'] )
-        || 'CiviCRM' !== $_GET['page'] ) {
+        || 'CiviCRM' !== $_GET['civiwp'] ) {
         return $canonical;
       }
       $path = $_GET['q'];
       unset( $_GET['q'] );
-      unset( $_GET['page'] );
+      unset( $_GET['civiwp'] );
       $query = http_build_query( $_GET );
 
     }

--- a/includes/civicrm.compat.php
+++ b/includes/civicrm.compat.php
@@ -137,7 +137,7 @@ class CiviCRM_For_WordPress_Compat {
         foreach ($rewrite as $path) {
           add_rewrite_rule(
             '^' . $path . '([^?]*)?',
-            'index.php?page_id=' . $post_id . '&page=CiviCRM&q=civicrm%2F$matches[1]',
+            'index.php?page_id=' . $post_id . '&civiwp=CiviCRM&q=civicrm%2F$matches[1]',
             'top'
           );
         }

--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -398,7 +398,7 @@ class CiviCRM_For_WordPress_Shortcodes {
       if (!$config->cleanURL) {
 
         // Construct query parts
-        $queryParts[] = 'page=CiviCRM';
+        $queryParts[] = 'civiwp=CiviCRM';
         if (isset($args['q'])) {
           $queryParts[] = 'q=' . $args['q'];
         }
@@ -815,8 +815,6 @@ class CiviCRM_For_WordPress_Shortcodes {
      */
     $params = apply_filters( 'civicrm_shortcode_api_params', array(
       'version' => 3,
-      'page' => 'CiviCRM',
-      'q' => 'civicrm/ajax/rest',
       'sequential' => '1',
     ), $atts, $args );
 


### PR DESCRIPTION
Overview
----------------------------------------
Additional PR against 5.26 branch. Same fix as #193. Requires [this PR on CiviCRM Core](https://github.com/civicrm/civicrm-core/pull/17352). Solves [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/49).