### PR TITLE
dev/wordpress#52 Accept empty string as q|qid for the REST endpoint civicrm/v3/url

### DIFF
--- a/wp-rest/Controller/Url.php
+++ b/wp-rest/Controller/Url.php
@@ -183,20 +183,20 @@ class Url extends Base {
 
 		return [
 			'qid' => [
-				'type' => 'integer',
+				'type' => ['integer', 'string'],
 				'required' => false,
 				'validate_callback' => function( $value, $request, $key ) {
 
-					return is_numeric( $value );
+					return is_numeric( $value ) || empty( $value );
 
 				}
 			],
 			'q' => [
-				'type' => 'integer',
+				'type' => ['integer', 'string'],
 				'required' => false,
 				'validate_callback' => function( $value, $request, $key ) {
 
-					return is_numeric( $value );
+					return is_numeric( $value ) || empty( $value );
 
 				}
 			],


### PR DESCRIPTION
Overview
----------------------------------------
See [dev/wordpress#52](https://lab.civicrm.org/dev/wordpress/-/issues/52).

Before
----------------------------------------
Clicking on a tracked link in a mailing from the 'Public view' screen responds with `Invalid parameter(s): qid`

After
----------------------------------------
Clicking on a tracked link in a mailing from the 'Public view' screen works as expected.
