### PR TITLE
Declare Minimum WP and PHP versions required for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ This is the development repository for the *CiviCRM* plugin for *WordPress*. Wha
 
 If you want to contribute to the development of this plugin, please bear the following in mind:
 
-* Bug fixes should go in the branch 4.5 branch (stable)* Structural changes should go under master (trunk, i.e. 4.6).
+* Bug Fixes and structural changes should go in the master branch.
+* Regression fixes should go in the current version branch.
 
 ----
-### About CiviCRM ###
-CiviCRM is web-based, open source, Constituent Relationship Management (CRM) software geared toward meeting the needs of non-profit and other civic-sector organizations.
+
+### About CiviCRM ###
+
+CiviCRM is web-based, open source, Constituent Relationship Management (CRM) software geared toward meeting the needs of non-profit and other civic-sector organizations.
 
 As a non profit committed to the public good itself, CiviCRM understands that forging and growing strong relationships with constituents is about more than collecting and tracking constituent data - it is about sustaining relationships with supporters over time.
 

--- a/civicrm.php
+++ b/civicrm.php
@@ -3,6 +3,8 @@
 Plugin Name: CiviCRM
 Description: CiviCRM - Growing and Sustaining Relationships
 Version: 4.7
+Requires at least: 4.9
+Requires PHP:      7.1
 Author: CiviCRM LLC
 Author URI: https://civicrm.org/
 Plugin URI: https://docs.civicrm.org/sysadmin/en/latest/install/wordpress/

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === CiviCRM ===
 Contributors: needle
 Tags: civicrm, crm
-Requires at least: 3.4
-Tested up to: 4.0
-Stable tag: 4.7
+Requires at least: 4.9
+Tested up to: 5.5
+Stable tag: 5.26.1
 License: AGPL3
 License URI: http://www.gnu.org/licenses/agpl-3.0.html
 
@@ -27,7 +27,7 @@ CiviCRM is localized in over 20 languages including: Chinese (Taiwan, China), Du
 == Installation ==
 
 1. Download CiviCRM for WordPress from the [CiviCRM website](https://civicrm.org/download)
-1. Extract the plugin archive 
+1. Extract the plugin archive
 1. Upload plugin files to your plugins directory, normally `/wp-content/plugins/`
 1. Follow the instructions on the [CiviCRM website](http://wiki.civicrm.org/confluence/display/CRMDOC/WordPress+Installation+Guide+for+CiviCRM+4.5)
 
@@ -35,12 +35,4 @@ CiviCRM is localized in over 20 languages including: Chinese (Taiwan, China), Du
 
 == Changelog ==
 
-= 4.5 =
-Support for CiviCRM version 4.5.x
-
-= 4.4 =
-Support for CiviCRM version 4.4.x
-
-= 4.3 =
-Support for CiviCRM version 4.3.x
-
+[Full Release Notes](https://github.com/civicrm/civicrm-core/blob/master/release-notes.md)


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM will fail to install on WP Versions less than 4.7  due to https://github.com/civicrm/civicrm-core/commit/742eb5c659cce650a3d3739ba341b065266db714

Based on https://lab.civicrm.org/dev/wordpress/-/issues/51  we want to update minimum WP version to 4.9

Before
----------------------------------------
CiviCRM install will fail on versions older than 4.7

After
----------------------------------------
CiviCRM cannot be activated unless WP meets the minimum requirement.  Added a php minimum as well

Technical Details
----------------------------------------


Comments
----------------------------------------
Once accepted we must update the docs
