### PR TITLE
remove / from the beginning and ending of query string

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1721,6 +1721,8 @@ class CiviCRM_For_WordPress {
 
     if (!empty($q)) {
       $argString = trim($q);
+      // remove / from the beginning and ending of query string.
+      $argString = trim($argString, '/');
       $args = explode('/', $argString);
     }
     $args = array_pad($args, 2, '');


### PR DESCRIPTION
Overview
----------------------------------------
When a query string has '/' in the beginning, it fails with ''You do not have permission to access this content.' error eg when you have `q=/civicrm/contribute/transact/` it generates $args after explode as 
```
Array
(
    [0] => 
    [1] => civicrm
    [2] => contribute
    [3] => transact
)
```

Which causes permission denied because of check in [check_permission() function](https://github.com/civicrm/civicrm-wordpress/blob/master/includes/civicrm.users.php#L105). 
