### PR TITLE
Do not start session on any CLI processes

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -367,7 +367,7 @@ class CiviCRM_For_WordPress {
      * There is no session handling in WP - hence we start it for CiviCRM pages
      * except when running via WP-CLI which does not require sessions.
      */
-    if ( empty( $session_id ) && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+    if ( empty( $session_id ) && ! ( defined( 'WP_CLI' ) && WP_CLI ) && ( PHP_SAPI !== 'cli' ) ) {
       session_start();
     }
 


### PR DESCRIPTION
This is a refinement of the idea in https://github.com/civicrm/civicrm-wordpress/pull/135 to address other CLI use-cases.

Before
-------

If I have a `wpmaster` site on on `bknix-max` (php73), and if I run `cv upgrade:db -vv`, then there are several warnings like this:

```
PHP Warning:  session_start(): Cannot send session cookie - headers already sent by (output started at phar:///Users/totten/bknix/bin/cv/.box/src/Printer.php:83) in /Users/totten/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm.php on line 371
PHP Stack trace:
PHP   1. {main}() /Users/totten/bknix/bin/cv:0
PHP   2. require() /Users/totten/bknix/bin/cv:14
PHP   3. Civi\Cv\Application::main() phar:///Users/totten/bknix/bin/cv/bin/cv:27
PHP   4. Civi\Cv\Application->run() phar:///Users/totten/bknix/bin/cv/src/Application.php:15
PHP   5. Civi\Cv\Application->doRun() phar:///Users/totten/bknix/bin/cv/vendor/symfony/console/Application.php:124
PHP   6. Civi\Cv\Application->doRun() phar:///Users/totten/bknix/bin/cv/src/Application.php:46
PHP   7. Civi\Cv\Application->doRunCommand() phar:///Users/totten/bknix/bin/cv/vendor/symfony/console/Application.php:193
PHP   8. Civi\Cv\Command\UpgradeDbCommand->run() phar:///Users/totten/bknix/bin/cv/vendor/symfony/console/Application.php:850
PHP   9. Civi\Cv\Command\UpgradeDbCommand->execute() phar:///Users/totten/bknix/bin/cv/vendor/symfony/console/Command/Command.php:257
PHP  10. Civi\Cv\Command\UpgradeDbCommand->boot() phar:///Users/totten/bknix/bin/cv/src/Command/UpgradeDbCommand.php:39
PHP  11. call_user_func:{phar:///Users/totten/bknix/bin/cv/src/Util/BootTrait.php:39}() phar:///Users/totten/bknix/bin/cv/src/Util/BootTrait.php:39
PHP  12. Civi\Cv\Command\UpgradeDbCommand->_boot_full() phar:///Users/totten/bknix/bin/cv/src/Util/BootTrait.php:39
PHP  13. CRM_Utils_System::loadBootStrap() phar:///Users/totten/bknix/bin/cv/src/Util/BootTrait.php:99
PHP  14. CRM_Utils_System_WordPress->loadBootStrap() /Users/totten/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/CRM/Utils/System.php:1521
PHP  15. require_once() /Users/totten/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/CRM/Utils/System/WordPress.php:600
PHP  16. require_once() /Users/totten/bknix/build/wpmaster/web/wp-load.php:37
PHP  17. require_once() /Users/totten/bknix/build/wpmaster/web/wp-config.php:97
PHP  18. do_action() /Users/totten/bknix/build/wpmaster/web/wp-settings.php:392
PHP  19. WP_Hook->do_action() /Users/totten/bknix/build/wpmaster/web/wp-includes/plugin.php:478
PHP  20. WP_Hook->apply_filters() /Users/totten/bknix/build/wpmaster/web/wp-includes/class-wp-hook.php:312
PHP  21. CiviCRM_For_WordPress->setup_instance() /Users/totten/bknix/build/wpmaster/web/wp-includes/class-wp-hook.php:288
PHP  22. session_start() /Users/totten/bknix/build/wpmaster/web/wp-content/plugins/civicrm/civicrm.php:371
```

After
-----

It doesn't try to start session in CLI (where sessions don't make sense).
