### PR TITLE
[REF] Fix DB upgrade process by ensuring that CIVICRM_UPGRADE_ACTIVE …

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -1046,6 +1046,10 @@ if ( ! defined( 'CIVICRM_WPCLI_LOADED' ) ) {
 
       civicrm_initialize();
 
+      if ( ! defined( 'CIVICRM_UPGRADE_ACTIVE' ) ) {
+        define( 'CIVICRM_UPGRADE_ACTIVE', 1 );
+      }
+
       if ( class_exists( 'CRM_Upgrade_Headless' ) ) {
         # Note: CRM_Upgrade_Headless introduced in 4.2 -- at the same time as class auto-loading
         try {


### PR DESCRIPTION
…is properly defined if only runing civicrm-upgrade-db action and not the full civicrm-upgrade action

Overview
----------------------------------------
This aims to fix an issue where by if someone ran just the civicrm-upgrade-db action only i.e. they manually downloaded their WordPress instance and they were running on a multilingual instance then it can fail as shown by https://test.civicrm.org/job/CiviCRM-WordPress-PR/lastCompletedBuild/testReport/(root)/CivicrmUpgradeTest/5_13_3_multilingual_af_bg_en_mysql_bz2/

Before
----------------------------------------
Upgrade process via CLI can fail if this define is not properly set

After
----------------------------------------
Upgrade process via CLI works consistently 

Technical Details
----------------------------------------
The issue is that without this define then CRM_Core_Config::isUpgradeMode() returns FALSE which causes this https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/I18n/Schema.php#L504 to return the wrong set of code causing the trigger creation to fail

ping @kcristiano 
