### PR TITLE
Prevent plugin from being auto-updated in WordPress 5.5

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -772,7 +772,32 @@ class CiviCRM_For_WordPress {
     // Enable shortcode modal
     $this->modal->register_hooks();
 
+		// Prevent auto-updates.
+		add_filter( 'plugin_auto_update_setting_html', [ $this, 'auto_update_prevent' ], 10, 3 );
+
   }
+
+
+	/**
+	 * Prevent auto-updates of this plugin in WordPress 5.5.
+	 *
+	 * @link https://make.wordpress.org/core/2020/07/15/controlling-plugin-and-theme-auto-updates-ui-in-wordpress-5-5/
+	 *
+	 * @since 5.28
+	 */
+	function auto_update_prevent( $html, $plugin_file, $plugin_data ) {
+
+		// Test for this plugin.
+		$this_plugin = plugin_basename( dirname( __FILE__ ) . '/civicrm.php' );
+		if ( $this_plugin === $plugin_file ) {
+			$html = __( 'Auto-updates are not available for this plugin.', 'civicrm' );
+		}
+
+		// --<
+		return $html;
+
+	}
+
 
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue in Lab/WordPress](https://lab.civicrm.org/dev/wordpress/-/issues/65).

Before
----------------------------------------
Auto-update available

<img width="1023" alt="Screen Shot 2020-07-18 at 10 59 40" src="https://user-images.githubusercontent.com/726936/87850150-edbeec80-c8e5-11ea-9716-42acfbbdc00b.png">

After
----------------------------------------
Auto-update not available

<img width="1027" alt="Screen Shot 2020-07-18 at 11 00 12" src="https://user-images.githubusercontent.com/726936/87850156-fa434500-c8e5-11ea-8de2-2a1c37405147.png">