### PR TITLE
Remove unused "ufUniqID" session variable

### DIFF
--- a/wp-rest/Plugin.php
+++ b/wp-rest/Plugin.php
@@ -352,7 +352,6 @@ class Plugin {
 		$session = \CRM_Core_Session::singleton();
 		$session->set( 'ufID', $wp_user->ID );
 		$session->set( 'userID', $uf_match['contact_id'] );
-		$session->set( 'ufUniqID', $uf_match['uf_name'] );
 
 	}
 


### PR DESCRIPTION
Overview
----------------------------------------
Companion PR to https://github.com/civicrm/civicrm-core/pull/17904 that removes needless code in this plugin.

See [this issue on Lab](https://lab.civicrm.org/dev/core/-/issues/1890) for discussion.