### PR TITLE
dev/wordpress#37 - Switch unambiguously to new installer UI

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1304,7 +1304,7 @@ class CiviCRM_For_WordPress {
     );
     foreach ($setupPaths as $setupPath) {
       $loader = implode(DIRECTORY_SEPARATOR, [$civicrmCore, $setupPath, 'civicrm-setup-autoload.php']);
-      if (file_exists($civicrmCore . DIRECTORY_SEPARATOR . '.use-civicrm-setup') && file_exists($loader)) {
+      if (file_exists($loader)) {
         require_once $loader;
         require_once implode(DIRECTORY_SEPARATOR, [$civicrmCore, 'CRM', 'Core', 'ClassLoader.php']);
         CRM_Core_ClassLoader::singleton()->register();
@@ -1326,17 +1326,7 @@ class CiviCRM_For_WordPress {
       }
     }
 
-    // Uses CIVICRM_PLUGIN_DIR instead of WP_PLUGIN_DIR
-    $installFile =
-      CIVICRM_PLUGIN_DIR .
-      'civicrm' . DIRECTORY_SEPARATOR .
-      'install' . DIRECTORY_SEPARATOR .
-      'index.php';
-
-    // Notice: Undefined variable: siteDir in:
-    // CIVICRM_PLUGIN_DIR/civicrm/install/index.php on line 456
-    include ( $installFile );
-
+    wp_die( __( 'Installer unavailable. Failed to locate CiviCRM libraries.', 'civicrm' ) );
   }
 
 


### PR DESCRIPTION
Overview
-------------

See https://lab.civicrm.org/dev/wordpress/-/issues/37

Before
------

To activate the new installer UI on WordPress, you need to either use the `civicrm-X.Y.Z-wporg.zip`
or manually create the file `.use-civicrm-setup`.

Otherwise, it uses the old installer.


![Screenshot from 2020-08-11 16-13-51](https://user-images.githubusercontent.com/1336047/89958078-dfff3d00-dbed-11ea-85a2-176168c3db46.png)

After
-----

The old installer is not available on WordPress. It only uses the new installer.

![Screenshot from 2020-08-11 16-13-31](https://user-images.githubusercontent.com/1336047/89958074-dece1000-dbed-11ea-8284-78a4b844e6af.png)
