### PR TITLE
Add permission_callback to register_rest_route calls

### DIFF
--- a/wp-rest/Controller/AuthorizeIPN.php
+++ b/wp-rest/Controller/AuthorizeIPN.php
@@ -31,6 +31,7 @@ class AuthorizeIPN extends Base {
 		register_rest_route( $this->get_namespace(), $this->get_rest_base(), [
 			[
 				'methods' => \WP_REST_Server::ALLMETHODS,
+				'permission_callback' => '__return_true',
 				'callback' => [ $this, 'get_item' ]
 			]
 		] );

--- a/wp-rest/Controller/Cxn.php
+++ b/wp-rest/Controller/Cxn.php
@@ -29,6 +29,7 @@ class Cxn extends Base {
 		register_rest_route( $this->get_namespace(), $this->get_rest_base(), [
 			[
 				'methods' => \WP_REST_Server::ALLMETHODS,
+				'permission_callback' => '__return_true',
 				'callback' => [ $this, 'get_item' ]
 			]
 		] );

--- a/wp-rest/Controller/Open.php
+++ b/wp-rest/Controller/Open.php
@@ -28,6 +28,7 @@ class Open extends Base {
 			[
 				'methods' => \WP_REST_Server::READABLE,
 				'callback' => [ $this, 'get_item' ],
+				'permission_callback' => '__return_true',
 				'args' => $this->get_item_args()
 			],
 			'schema' => [ $this, 'get_item_schema' ]

--- a/wp-rest/Controller/PayPalIPN.php
+++ b/wp-rest/Controller/PayPalIPN.php
@@ -29,6 +29,7 @@ class PayPalIPN extends Base {
 		register_rest_route( $this->get_namespace(), $this->get_rest_base(), [
 			[
 				'methods' => \WP_REST_Server::ALLMETHODS,
+				'permission_callback' => '__return_true',
 				'callback' => [ $this, 'get_item' ]
 			]
 		] );

--- a/wp-rest/Controller/PxIPN.php
+++ b/wp-rest/Controller/PxIPN.php
@@ -29,6 +29,7 @@ class PxIPN extends Base {
 		register_rest_route( $this->get_namespace(), $this->get_rest_base(), [
 			[
 				'methods' => \WP_REST_Server::ALLMETHODS,
+				'permission_callback' => '__return_true',
 				'callback' => [ $this, 'get_item' ]
 			]
 		] );

--- a/wp-rest/Controller/Soap.php
+++ b/wp-rest/Controller/Soap.php
@@ -29,6 +29,7 @@ class Soap extends Base {
 		register_rest_route( $this->get_namespace(), $this->get_rest_base(), [
 			[
 				'methods' => \WP_REST_Server::ALLMETHODS,
+				'permission_callback' => '__return_true',
 				'callback' => [ $this, 'get_item' ]
 			]
 		] );

--- a/wp-rest/Controller/Url.php
+++ b/wp-rest/Controller/Url.php
@@ -28,6 +28,7 @@ class Url extends Base {
 			[
 				'methods' => \WP_REST_Server::READABLE,
 				'callback' => [ $this, 'get_item' ],
+				'permission_callback' => '__return_true',
 				'args' => $this->get_item_args()
 			],
 			'schema' => [ $this, 'get_item_schema' ]

--- a/wp-rest/Controller/Widget.php
+++ b/wp-rest/Controller/Widget.php
@@ -30,6 +30,7 @@ class Widget extends Base {
 			[
 				'methods' => \WP_REST_Server::READABLE,
 				'callback' => [ $this, 'get_item' ],
+				'permission_callback' => '__return_true',
 				'args' => $this->get_item_args()
 			],
 			'schema' => [ $this, 'get_item_schema' ]


### PR DESCRIPTION
Overview
----------------------------------------
Since release of WordPress 5.5, `permission_callback` is a mandatory parameter for `register_rest_route`

Clean PR for #217 

Before
----------------------------------------
A lot of PHP Warnings in logs

After
----------------------------------------
No warnings

Technical Details
----------------------------------------
This is described in https://make.wordpress.org/core/2020/07/22/rest-api-changes-in-wordpress-5-5/

