### PR TITLE
Ensure "civicrm_initialized" action only fires once

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1183,14 +1183,14 @@ class CiviCRM_For_WordPress {
 
       }
 
-    }
+      /**
+       * Broadcast that CiviCRM is now initialized.
+       *
+       * @since 4.4
+       */
+      do_action( 'civicrm_initialized' );
 
-    /**
-     * Broadcast that CiviCRM is now initialized.
-     *
-     * @since 4.4
-     */
-    do_action( 'civicrm_initialized' );
+    }
 
     // Success!
     return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
At present, the `civicrm_initialized` action fires every time `civi_wp()->initialize()` is called. This should only happen once.

Before
----------------------------------------
The `civicrm_initialized` action fires every time `civi_wp()->initialize()` is called.

After
----------------------------------------
The `civicrm_initialized` action fires only when `civi_wp()->initialize()` actually initialises CiviCRM.

Technical Details
----------------------------------------
Code that listens for the `civicrm_initialized` action receives callbacks every time `civi_wp()->initialize()` is called. This appears to have been an error on my part when refactoring for CiviCRM 4.6. This PR implements the intended behaviour.