### PR TITLE
Allow wp-cli upgrade command to proceed when there is only a single settings file

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -924,7 +924,7 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
       $legacy_settings_file = $plugins_dir . '/civicrm.settings.php';
       $upload_dir      = wp_upload_dir();
       $settings_file     = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
-      if (!file_exists($legacy_settings_file) || !file_exists($settings_file)) {
+      if (!file_exists($legacy_settings_file) && !file_exists($settings_file)) {
         return WP_CLI::error('Unable to locate settings file at ' . $legacy_settings_file . 'or at ' . $settings_file);
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the immediate issue raised in #216 so that upgrades proceed.

Before
----------------------------------------
The upgrade command fails on with "Unable to locate settings file at..." unless there is a `civicrm.settings.php` file in both the legacy and current locations.

After
----------------------------------------
The upgrade command proceeds if a `civicrm.settings.php` file is found in either the legacy or the current locations.

Comments
----------------------------------------
This PR does not address what follows the settings file check but then nor does #216 either really. The consensus seems to be that when pre CiviCRM 4.7 installs are upgraded, their `civicrm.settings.php` file in the legacy location should be moved to the current `wp_uploads_dir()` location.

The [analysis by @kcristiano on #216] should be followed when fixing this in a fresh PR.