### PR TITLE
wordpress#63 Add action parameter to PCP shortcode

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -704,7 +704,18 @@ class CiviCRM_For_WordPress_Shortcodes {
         if ($mode == 'preview' || $mode == 'test') {
           $args['action'] = 'preview';
         }
-        $args['q'] = 'civicrm/pcp/info';
+
+        switch ($action) {
+          case 'transact':
+            $args['q'] = 'civicrm/contribute/transact';
+            $args['pcpId'] = $args['id'];
+            break;
+
+          case 'info':
+          default:
+            $args['q'] = 'civicrm/pcp/info';
+            break;
+        }
         break;
 
       case 'event':


### PR DESCRIPTION
Overview
----------------------------------------
Add action parameter to PCP shortcode per https://lab.civicrm.org/dev/wordpress/-/issues/63

The parameters chosen are "info" and "transact" because I think this makes more sense than using "register" as used by event.

Requires https://github.com/civicrm/civicrm-core/pull/19058

Before
----------------------------------------
No action parameter for PCP shortcodes.

After
----------------------------------------
Action parameter for PCP shortcodes.

Technical Details
----------------------------------------


Comments
----------------------------------------
@kcristiano @christianwach 