### PR TITLE
Fix dev/core#2278 - pass contributionPageID as argument for PCP transact shortcodes

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -735,6 +735,10 @@ class CiviCRM_For_WordPress_Shortcodes {
           case 'transact':
             $args['q'] = 'civicrm/contribute/transact';
             $args['pcpId'] = $args['id'];
+            $args['id'] = civicrm_api3('Pcp', 'getvalue', [
+              'return' => 'page_id',
+              'id' => $args['pcpId'],
+            ]);
             break;
 
           case 'info':


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/2278

Before
----------------------------------------
Wrong contribution page ID passed.

After
----------------------------------------
Correct contribution page ID passed.

Technical Details
----------------------------------------
We do a simple lookup via the API for the contributionPageID linked to the personal campaign page.

Comments
----------------------------------------
@kcristiano @christianwach

This is a 5.33 backport and will need pushing to master too if approved.