### PR TITLE
Fix Typo on function call preventing activation / install of CiviCRM

### DIFF
--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -117,7 +117,7 @@ class CiviCRM_For_WordPress_Admin {
    */
   public function run_installer() {
 
-    $this->assert_php_pupport();
+    $this->assert_php_support();
 
     $civicrmCore = CIVICRM_PLUGIN_DIR . 'civicrm';
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a typo in the function call

Before
----------------------------------------
Cannot activate plugin

After
----------------------------------------
Can activate plugin

@kcristiano 
