### PR TITLE
dev/core#2258 - Define CIVICRM_CRED_KEYS during wp-cli installation

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -454,7 +454,8 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
         'CMSdbPass'          => DB_PASSWORD,
         'CMSdbHost'          => DB_HOST,
         'CMSdbName'          => DB_NAME,
-        'siteKey'            => md5(rand() . mt_rand() . rand() . uniqid('', TRUE) . $params['baseURL']),
+        'siteKey'            => preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(32))),
+        'credKeys'           => 'aes-cbc:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(32))),
       ];
 
       $str = file_get_contents($tplPath . 'civicrm.settings.php.template');

--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -377,7 +377,7 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
         define('DB_DSN_MODE', 'auto');
       }
 
-      require_once "$crmPath/packages/DB.php";
+      include_once "$crmPath/vendor/pear/db/DB.php";
 
       $db = DB::connect($dsn);
       if (DB::iserror($db)) {


### PR DESCRIPTION
Overview
----------------------------------------
When using `wp civicrm install`, the `civicrm.settings.php` should have a credential-key.

See also: civicrm/civicrm-core#19349 and https://lab.civicrm.org/dev/core/-/issues/2258

Before
----------------------------------------

Blank key

After
----------------------------------------

Random key

Technical Details
----------------------------------------

Here's an example run:

```
## Remove old installation
[bknix-min:~/bknix/build/wpmaster/web/wp-content/plugins/civicrm] amp create -Ncivi -r ~/bknix/build/wpmaster/web/ --skip-url -f ; rm ~/bknix/build/wpmaster/web/wp-content/
uploads/civicrm/civicrm.settings.php -f
AMP_URL=''
AMP_ROOT='/home/totten/bknix/build/wpmaster/web'
AMP_DB_DSN='mysql://wpmasterci_w2l51:SsPCzWV8TAWAQDAU@127.0.0.1:3307/wpmastercivi_i8z5e?new_link=true'
AMP_DB_USER='wpmasterci_w2l51'
AMP_DB_PASS='********'
AMP_DB_HOST='127.0.0.1'
AMP_DB_PORT='3307'
AMP_DB_NAME='wpmastercivi_i8z5e'
AMP_DB_ARGS='--defaults-file='\''/home/totten/bknix/.loco/var.keep/amp/my.cnf.d/my.cnf-aa35d504c2228a5e53f6660d84b421eb'\'' wpmastercivi_i8z5e'

## Install
[bknix-min:~/bknix/build/wpmaster/web/wp-content/plugins/civicrm] wp civicrm install --dbuser=wpmasterci_w2l51 --dbpass=******** --dbhost=127.0.0.1:3307 --dbname=wpmastercivi_i8z5e
Success: Using installer files found on the site.
Loading CiviCRM database structure ..
Loading CiviCRM database with required data ..
Success: CiviCRM database loaded successfully.
Generating civicrm settings file ..
Success: Settings file generated: /home/totten/bknix/build/wpmaster/web/wp-content/uploads/civicrm/civicrm.settings.php
Warning: Plugin 'civicrm' is already active.
Success: Plugin already activated.
Success: CiviCRM installed.

## Inspect outcome
[bknix-min:~/bknix/build/wpmaster/web/wp-content/plugins/civicrm] cv ev 'print_r(Civi::service("crypto.registry")->getKeys()); print_r([CIVICRM_CRED_KEYS]);'
Array
(
    [plain] => Array
        (
            [key] => 
            [suite] => plain
            [tags] => Array
                (
                )

            [id] => plain
            [weight] => 32768
        )

    [plain0] => Array
        (
            [suite] => plain
            [weight] => 32768
            [tags] => Array
                (
                    [0] => CRED
                )

            [id] => plain0
        )

    [********] => Array
        (
            [suite] => aes-cbc
            [weight] => 0
            [key] => ********
            [tags] => Array
                (
                    [0] => CRED
                )

            [id] => ********
        )

)
Array
(
    [0] => aes-cbc:hkdf-sha256:*********
)


```