### PR TITLE
dev/core#2204 Make minimum PHP required for install to be 7.2

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -4,7 +4,7 @@
  * Description: CiviCRM - Growing and Sustaining Relationships
  * Version: 4.7
  * Requires at least: 4.9
- * Requires PHP:      7.1
+ * Requires PHP:      7.2
  * Author: CiviCRM LLC
  * Author URI: https://civicrm.org/
  * Plugin URI: https://docs.civicrm.org/sysadmin/en/latest/install/wordpress/
@@ -83,7 +83,7 @@ if (!defined('CIVICRM_WP_PHP_MINIMUM')) {
    * @see CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER
    * @see CiviWP\PhpVersionTest::testConstantMatch()
    */
-  define('CIVICRM_WP_PHP_MINIMUM', '7.1.0');
+  define('CIVICRM_WP_PHP_MINIMUM', '7.2.0');
 }
 
 /*

--- a/wp-rest/README.md
+++ b/wp-rest/README.md
@@ -4,7 +4,7 @@ This is a WordPress plugin that aims to expose CiviCRM's [extern](https://github
 
 This plugin requires:
 
--   PHP 7.1+
+-   PHP 7.2+
 -   WordPress 4.7+
 -   CiviCRM to be installed and activated.
 


### PR DESCRIPTION
Overview
----------------------------------------
As per [dev/core#2204](https://lab.civicrm.org/dev/core/-/issues/2204) This makes the minimum PHP version required to be 7.2

Before
----------------------------------------
Minimum PHP version = 7.1

After
----------------------------------------
Minimum PHP version = 7.2

ping @eileenmcnaughton @totten 