### PR TITLE
Remove Base Page content filter once it has been used

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -522,6 +522,9 @@ class CiviCRM_For_WordPress_Basepage {
    */
   public function basepage_render() {
 
+    // We no longer need this filter, so remove it.
+    remove_filter('the_content', [$this, 'basepage_render']);
+
     // Hand back our base page markup.
     return $this->basepage_markup;
 


### PR DESCRIPTION
Overview
----------------------------------------
Solves [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/91).

Before
----------------------------------------
CiviCRM content is rendered each time `the_content()` is called on a page.

After
----------------------------------------
CiviCRM content is rendered the first time `the_content()` is called.