### PR TITLE
Fix access permissions for sub-pages and "Quick Add" dashlet

### DIFF
--- a/includes/admin-metaboxes/civicrm.metabox.contact.add.php
+++ b/includes/admin-metaboxes/civicrm.metabox.contact.add.php
@@ -69,6 +69,11 @@ class CiviCRM_For_WordPress_Admin_Metabox_Contact_Add {
    */
   public function register_hooks() {
 
+    // Bail if the current WordPress User cannot add Contacts.
+    if (!$this->civi->users->check_civicrm_permission('add_contacts')) {
+      return;
+    }
+
     // Add our meta boxes.
     add_action('wp_dashboard_setup', [$this, 'meta_box_add']);
 

--- a/includes/admin-pages/civicrm.page.integration.php
+++ b/includes/admin-pages/civicrm.page.integration.php
@@ -89,6 +89,25 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
   }
 
   /**
+   * Get the capability required to access the Settings Page.
+   *
+   * @since 5.35
+   */
+  public function access_capability() {
+
+    /**
+     * Return default capability but allow overrides.
+     *
+     * @since 5.35
+     *
+     * @param str The default access capability.
+     * @return str The modified access capability.
+     */
+    return apply_filters('civicrm/admin/integration/cap', 'manage_options');
+
+  }
+
+  /**
    * Adds CiviCRM sub-menu items to WordPress admin menu.
    *
    * @since 5.34
@@ -100,12 +119,15 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
       return;
     }
 
+    // Get access capability.
+    $capability = $this->access_capability();
+
     // Add Integration submenu item.
     $integration_page = add_submenu_page(
       'CiviCRM',
       __('Integrating CiviCRM with WordPress', 'civicrm'),
       __('Integration', 'civicrm'),
-      'access_civicrm',
+      $capability,
       'civi_integration',
       [$this, 'page_integration']
     );
@@ -208,8 +230,9 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
       return;
     }
 
-    // Bail if user cannot access CiviCRM.
-    if (!current_user_can('access_civicrm')) {
+    // Bail if user cannot access the Integration Page.
+    $capability = $this->access_capability();
+    if (!current_user_can($capability)) {
       return;
     }
 

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -91,18 +91,40 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
   }
 
   /**
+   * Get the capability required to access the Settings Page.
+   *
+   * @since 5.35
+   */
+  public function access_capability() {
+
+    /**
+     * Return default capability but allow overrides.
+     *
+     * @since 5.35
+     *
+     * @param str The default access capability.
+     * @return str The modified access capability.
+     */
+    return apply_filters('civicrm/admin/settings/cap', 'manage_options');
+
+  }
+
+  /**
    * Adds CiviCRM sub-menu items to WordPress admin menu.
    *
    * @since 5.34
    */
   public function add_menu_items() {
 
+    // Get access capability.
+    $capability = $this->access_capability();
+
     // Add Settings submenu item.
     $options_page = add_submenu_page(
       'CiviCRM',
       __('CiviCRM Settings for WordPress', 'civicrm'),
       __('Settings', 'civicrm'),
-      'access_civicrm',
+      $capability,
       $this->slug,
       [$this, 'page_options']
     );
@@ -260,8 +282,9 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
       return;
     }
 
-    // Bail if user cannot access CiviCRM.
-    if (!current_user_can('access_civicrm')) {
+    // Bail if user cannot access the Settings Page.
+    $capability = $this->access_capability();
+    if (!current_user_can($capability)) {
       return;
     }
 

--- a/includes/civicrm.users.php
+++ b/includes/civicrm.users.php
@@ -125,6 +125,33 @@ class CiviCRM_For_WordPress_Users {
   }
 
   /**
+   * Check a CiviCRM permission.
+   *
+   * @since 5.35
+   *
+   * @param str $permission The permission string.
+   * @return bool $permitted True if allowed, false otherwise.
+   */
+  public function check_civicrm_permission($permission) {
+
+    // Always deny if CiviCRM is not initialised.
+    if (!$this->civi->initialize()) {
+      return FALSE;
+    }
+
+    // Deny by default.
+    $permitted = FALSE;
+
+    // Check CiviCRM permissions.
+    if (CRM_Core_Permission::check($permission)) {
+      $permitted = TRUE;
+    }
+
+    return $permitted;
+
+  }
+
+  /**
    * Get "permission denied" text.
    *
    * Called when authentication fails in basepage_register_hooks()


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue](https://lab.civicrm.org/dev/wordpress/-/issues/96) on Lab.

Before
----------------------------------------
Incorrect capabilities are assigned to Settings (and currently-disabled Integration) sub-pages and the "Quick Add" dashlet.

After
----------------------------------------
More appropriate capabilities are assigned to Settings (and currently-disabled Integration) sub-pages and the "Quick Add" dashlet.

Technical Details
----------------------------------------
As noted on the issue, `manage_options` seems a more sensible default capability than `administer_civicrm` for the sub-pages because `administer_civicrm` is not automatically granted to WordPress admins. I have added a filter for each page so that this can be overridden if required.

The "Quick Add" dashlet queries CiviCRM directly for the `add_contacts` permission because the permission may or may not have been granted to the WordPress User and therefore `current_user_can()` can't necessarily determine the User's status.