### PR TITLE
Prevent pages and metabox from loading until CiviCRM is installed

### DIFF
--- a/includes/admin-metaboxes/civicrm.metabox.contact.add.php
+++ b/includes/admin-metaboxes/civicrm.metabox.contact.add.php
@@ -51,6 +51,11 @@ class CiviCRM_For_WordPress_Admin_Metabox_Contact_Add {
    */
   public function __construct() {
 
+    // Bail if CiviCRM is not installed.
+    if (!CIVICRM_INSTALLED) {
+      return;
+    }
+
     // Store reference to CiviCRM plugin object.
     $this->civi = civi_wp();
 

--- a/includes/admin-pages/civicrm.page.integration.php
+++ b/includes/admin-pages/civicrm.page.integration.php
@@ -62,6 +62,11 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
     // Disable until Messages API is active.
     return;
 
+    // Bail if CiviCRM is not installed.
+    if (!CIVICRM_INSTALLED) {
+      return;
+    }
+
     // Store reference to CiviCRM plugin object.
     $this->civi = civi_wp();
 

--- a/includes/admin-pages/civicrm.page.integration.php
+++ b/includes/admin-pages/civicrm.page.integration.php
@@ -96,14 +96,14 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
   /**
    * Get the capability required to access the Settings Page.
    *
-   * @since 5.35
+   * @since 5.37
    */
   public function access_capability() {
 
     /**
      * Return default capability but allow overrides.
      *
-     * @since 5.35
+     * @since 5.37
      *
      * @param str The default access capability.
      * @return str The modified access capability.

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -59,6 +59,11 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
    */
   public function __construct() {
 
+    // Bail if CiviCRM is not installed.
+    if (!CIVICRM_INSTALLED) {
+      return;
+    }
+
     // Store reference to CiviCRM plugin object.
     $this->civi = civi_wp();
 

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -98,14 +98,14 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
   /**
    * Get the capability required to access the Settings Page.
    *
-   * @since 5.35
+   * @since 5.37
    */
   public function access_capability() {
 
     /**
      * Return default capability but allow overrides.
      *
-     * @since 5.35
+     * @since 5.37
      *
      * @param str The default access capability.
      * @return str The modified access capability.


### PR DESCRIPTION
Overview
----------------------------------------
The CiviCRM Settings and Integration pages and the Quick Add Metabox should not load unless CiviCRM has been installed. Follow up PR to #245

Before
----------------------------------------
Pages and Metabox load during installation.

After
----------------------------------------
Pages and Metabox do not load during installation.

Comments
----------------------------------------
The Quick Add Metabox was calling `CiviCRM_For_WordPress::initialize()` during the install process and causing an infinite redirect. This is fixed as a result of this PR.

Also applies the correct `@since` tag to the new methods.