### PR TITLE
Update PHPUnit for PHPUnit8 config to ensure we don't cache test results

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
          stopOnFailure="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="tests/phpunit/bootstrap.php"
+         cacheResult="false"
 >
   <testsuites>
     <testsuite name="CiviCRM-WordPress Test Suite">


### PR DESCRIPTION
Overview
----------------------------------------
Update phpunit configuration to not cache results which happens in PHPUnit8

Before
----------------------------------------
Configuration doesn't stop caching of results

After
----------------------------------------
No caching of results
