### PR TITLE
Fail gracefully when errors are detected

### DIFF
--- a/assets/templates/metaboxes/metabox.error.help.php
+++ b/assets/templates/metaboxes/metabox.error.help.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+?><!-- assets/templates/metaboxes/metabox.error.help.php -->
+<p><?php printf(
+  __('Please review the %1$sWordPress Installation Guide%2$s and the %3$sTroubleshooting page%4$s for assistance. If you still need help, you can often find solutions to your issue by searching for the error message in the %5$sinstallation support section of the community forum%6$s.', 'civicrm'),
+  '<a href="https://docs.civicrm.org/installation/en/latest/wordpress/">', '</a>',
+  '<a href="https://docs.civicrm.org/sysadmin/en/latest/troubleshooting/">', '</a>',
+  '<a href="https://civicrm.stackexchange.com/">', '</a>'
+); ?></p>

--- a/assets/templates/metaboxes/metabox.error.path.php
+++ b/assets/templates/metaboxes/metabox.error.path.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+?><!-- assets/templates/metaboxes/metabox.error.path.php -->
+<p><?php printf(
+  __('The path for including CiviCRM code files does appear to be set properly. Most likely there is an error in the %s setting in your CiviCRM settings file.', 'civicrm'),
+  '<code>civicrm_root</code>'
+); ?></p>
+
+<p><?php _e('Your CiviCRM settings file location is set to:', 'civicrm'); ?><br><pre><?php echo CIVICRM_SETTINGS_PATH; ?></pre></p>
+
+<p><?php printf(__('%s is currently set to:', 'civicrm'), '<code>civicrm_root</code>'); ?><br><pre><?php echo $civicrm_root; ?></pre></p>
+
+<p><?php printf(__('Please check that your CiviCRM settings file is where it should be and that %s is set correctly in it. Also check that the CiviCRM code directory is where it should be. If these are both fine, then you will have to look in your logs for more information.', 'civicrm'), '<code>civicrm_root</code>'); ?></p>

--- a/assets/templates/metaboxes/metabox.error.php.php
+++ b/assets/templates/metaboxes/metabox.error.php.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+?><!-- assets/templates/metaboxes/metabox.error.php.php -->
+<p><?php printf(
+  __('CiviCRM requires PHP version %1$s or greater. You are running PHP version %2$s', 'civicrm'),
+  CIVICRM_WP_PHP_MINIMUM,
+  PHP_VERSION
+); ?></p>
+
+<p><?php _e('You will have to upgrade PHP before you can run this version CiviCRM.', 'civicrm'); ?></p>
+
+<p><?php _e('To continue using CiviCRM without upgrading PHP, you will have to revert both the plugin and the database to a backup of your previous version.', 'civicrm'); ?></p>

--- a/assets/templates/pages/page.error.php
+++ b/assets/templates/pages/page.error.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+?><!-- assets/templates/page.error.php -->
+<div class="wrap civicrm-wrap civicrm-error-wrap">
+
+  <img src="<?php echo CIVICRM_PLUGIN_URL . 'assets/images/civicrm-logo.png'; ?>" width="160" height="42" alt="<?php esc_attr_e('CiviCRM Logo', 'civicrm'); ?>" id="civicrm-logo">
+
+  <h1><?php _e('CiviCRM Troubleshooting', 'civicrm'); ?></h1>
+
+  <p><?php _e('Something seems to be wrong with your CiviCRM installation. This page will help you try and troubleshoot the problem.', 'civicrm'); ?></p>
+
+  <form method="post" id="civicrm_error_form" action="">
+
+    <?php wp_nonce_field('meta-box-order', 'meta-box-order-nonce', FALSE); ?>
+    <?php wp_nonce_field('closedpostboxes', 'closedpostboxesnonce', FALSE); ?>
+    <?php wp_nonce_field('civicrm_error_form_action', 'civicrm_error_form_nonce'); ?>
+
+    <div id="poststuff">
+
+      <div id="post-body" class="metabox-holder columns-<?php echo $columns;?>">
+
+        <div id="postbox-container-1" class="postbox-container">
+          <?php do_meta_boxes($screen->id, 'side', NULL); ?>
+        </div>
+
+        <div id="postbox-container-2" class="postbox-container">
+          <?php do_meta_boxes($screen->id, 'normal', NULL);  ?>
+          <?php do_meta_boxes($screen->id, 'advanced', NULL); ?>
+        </div>
+
+      </div><!-- #post-body -->
+      <br class="clear">
+
+    </div><!-- #poststuff -->
+
+  </form>
+
+</div><!-- /.wrap -->

--- a/civicrm.php
+++ b/civicrm.php
@@ -311,8 +311,10 @@ class CiviCRM_For_WordPress {
 
     // Change option so this action never fires again.
     update_option('civicrm_activation_in_progress', 'false');
+
+    // Try and redirect to the Installer page.
     if (!is_multisite() && !isset($_GET['activate-multi']) && !CIVICRM_INSTALLED) {
-      wp_redirect(admin_url('options-general.php?page=civicrm-install'));
+      wp_redirect(admin_url('admin.php?page=civicrm-install'));
       exit;
     }
   }
@@ -1073,6 +1075,10 @@ class CiviCRM_For_WordPress {
    * @since 4.4
    */
   public function wp_head() {
+
+    if (!$this->initialize()) {
+      return;
+    }
 
     /*
      * CRM-11823

--- a/includes/admin-metaboxes/civicrm.metabox.contact.add.php
+++ b/includes/admin-metaboxes/civicrm.metabox.contact.add.php
@@ -74,7 +74,10 @@ class CiviCRM_For_WordPress_Admin_Metabox_Contact_Add {
    */
   public function register_hooks() {
 
-    // Bail if the current WordPress User cannot add Contacts.
+    /*
+     * Bail if the current WordPress User cannot add Contacts.
+     * Usefully, this also returns FALSE if CiviCRM fails to initialize.
+     */
     if (!$this->civi->users->check_civicrm_permission('add_contacts')) {
       return;
     }

--- a/includes/admin-pages/civicrm.page.error.php
+++ b/includes/admin-pages/civicrm.page.error.php
@@ -1,0 +1,327 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+/**
+ * Define CiviCRM_For_WordPress_Admin_Page_Error Class.
+ *
+ * @since 5.40
+ */
+class CiviCRM_For_WordPress_Admin_Page_Error {
+
+  /**
+   * @var object
+   * Plugin object reference.
+   * @since 5.40
+   * @access public
+   */
+  public $civi;
+
+  /**
+   * @var object
+   * Admin object reference.
+   * @since 5.40
+   * @access public
+   */
+  public $admin;
+
+  /**
+   * Instance constructor.
+   *
+   * This class is constructed during the "admin_menu" action at priority 9.
+   *
+   * @since 5.40
+   *
+   * @param str $logo The CiviCRM logo.
+   * @param str $position The default menu position expressed as a float.
+   */
+  public function __construct($logo, $position) {
+
+    // Store reference to CiviCRM plugin object.
+    $this->civi = civi_wp();
+
+    // Store reference to admin object.
+    $this->admin = civi_wp()->admin;
+
+    // Add items to the CiviCRM admin menu.
+    $this->add_menu_items($logo, $position);
+
+    // Add our meta boxes.
+    add_action('add_meta_boxes', [$this, 'meta_boxes_error_add']);
+
+  }
+
+  /**
+   * Get the capability required to access the Settings Page.
+   *
+   * @since 5.40
+   */
+  public function access_capability() {
+
+    /**
+     * Return default capability but allow overrides.
+     *
+     * @since 5.40
+     *
+     * @param str The default access capability.
+     * @return str The modified access capability.
+     */
+    return apply_filters('civicrm/admin/error/cap', 'manage_options');
+
+  }
+
+  /**
+   * Adds CiviCRM sub-menu items to WordPress admin menu.
+   *
+   * @since 5.40
+   *
+   * @param str $logo The CiviCRM logo.
+   * @param str $position The default menu position expressed as a float.
+   */
+  public function add_menu_items($logo, $position) {
+
+    // Get access capability.
+    $capability = $this->access_capability();
+
+    // Add our top level menu item.
+    $error_page = add_menu_page(
+      __('Troubleshooting', 'civicrm'),
+      __('CiviCRM', 'civicrm'),
+      $capability,
+      'CiviCRM',
+      [$this, 'page_error'],
+      $logo,
+      $position
+    );
+
+    // Add scripts for this page.
+    add_action('admin_head-' . $error_page, [$this, 'admin_head']);
+    add_action('admin_print_styles-' . $error_page, [$this, 'admin_css']);
+
+  }
+
+  /**
+   * Enqueue WordPress scripts on the pages that need them.
+   *
+   * @since 5.40
+   */
+  public function admin_head() {
+
+    // Enqueue WordPress scripts.
+    wp_enqueue_script('common');
+    wp_enqueue_script('jquery-ui-sortable');
+    wp_enqueue_script('dashboard');
+
+  }
+
+  /**
+   * Enqueue stylesheet on this page.
+   *
+   * @since 5.40
+   */
+  public function admin_css() {
+
+    // Enqueue common CSS.
+    wp_enqueue_style(
+      'civicrm-admin-styles',
+      CIVICRM_PLUGIN_URL . 'assets/css/civicrm.admin.css',
+      NULL,
+      CIVICRM_PLUGIN_VERSION,
+      'all'
+    );
+
+  }
+
+  // ---------------------------------------------------------------------------
+  // Page Loader
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Render the CiviCRM Error page.
+   *
+   * @since 5.40
+   */
+  public function page_error() {
+
+    // Get the current screen object.
+    $screen = get_current_screen();
+
+    /**
+     * Allow meta boxes to be added to this screen.
+     *
+     * The Screen ID to use is: "civicrm_page_civi_error".
+     *
+     * @since 5.40
+     *
+     * @param str $screen_id The ID of the current screen.
+     */
+    do_action('add_meta_boxes', $screen->id, NULL);
+
+    // Grab columns.
+    $columns = (1 == $screen->get_columns() ? '1' : '2');
+
+    // Include template file.
+    include CIVICRM_PLUGIN_DIR . 'assets/templates/pages/page.error.php';
+
+  }
+
+  // ---------------------------------------------------------------------------
+  // Meta Box Loaders
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register Error Page meta boxes.
+   *
+   * @since 5.40
+   *
+   * @param str $screen_id The Admin Page Screen ID.
+   */
+  public function meta_boxes_error_add($screen_id) {
+
+    // Define valid Screen IDs.
+    $screen_ids = [
+      'toplevel_page_CiviCRM',
+    ];
+
+    // Bail if not the Screen ID we want.
+    if (!in_array($screen_id, $screen_ids)) {
+      return;
+    }
+
+    // Bail if user cannot access the Error Page.
+    $capability = $this->access_capability();
+    if (!current_user_can($capability)) {
+      return;
+    }
+
+    // Init data.
+    $data = [];
+
+    // Check for PHP version flag.
+    if (civi_wp()->admin->error_flag === 'php-version') {
+
+      // Create "PHP Error Information" metabox.
+      add_meta_box(
+        'civicrm_error_php',
+        __('PHP Error Information', 'civicrm'),
+        // Callback.
+        [$this, 'meta_box_error_php_render'],
+        // Screen ID.
+        $screen_id,
+        // Column: options are 'normal' and 'side'.
+        'normal',
+        // Vertical placement: options are 'core', 'high', 'low'.
+        'core',
+        $data
+      );
+
+    }
+    else {
+
+      // Create "Path Error Information" metabox.
+      add_meta_box(
+        'civicrm_error_path',
+        __('Path Error Information', 'civicrm'),
+        // Callback.
+        [$this, 'meta_box_error_path_render'],
+        // Screen ID.
+        $screen_id,
+        // Column: options are 'normal' and 'side'.
+        'normal',
+        // Vertical placement: options are 'core', 'high', 'low'.
+        'core',
+        $data
+      );
+
+    }
+
+    // Create "General Information" metabox.
+    add_meta_box(
+      'civicrm_error_help',
+      __('General Information', 'civicrm'),
+      // Callback.
+      [$this, 'meta_box_error_help_render'],
+      // Screen ID.
+      $screen_id,
+      // Column: options are 'normal' and 'side'.
+      'normal',
+      // Vertical placement: options are 'core', 'high', 'low'.
+      'core',
+      $data
+    );
+
+  }
+
+  // ---------------------------------------------------------------------------
+  // Meta Box Renderers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Render "General Information" meta box.
+   *
+   * @since 5.40
+   *
+   * @param mixed $unused Unused param.
+   * @param array $metabox Array containing id, title, callback, and args elements.
+   */
+  public function meta_box_error_help_render($unused = NULL, $metabox) {
+
+    // Include template file.
+    include CIVICRM_PLUGIN_DIR . 'assets/templates/metaboxes/metabox.error.help.php';
+
+  }
+
+  /**
+   * Render "PHP Error Information" meta box.
+   *
+   * @since 5.40
+   *
+   * @param mixed $unused Unused param.
+   * @param array $metabox Array containing id, title, callback, and args elements.
+   */
+  public function meta_box_error_php_render($unused = NULL, $metabox) {
+
+    global $civicrm_root;
+
+    // Include template file.
+    include CIVICRM_PLUGIN_DIR . 'assets/templates/metaboxes/metabox.error.php.php';
+
+  }
+
+  /**
+   * Render "Path Error Information" meta box.
+   *
+   * @since 5.40
+   *
+   * @param mixed $unused Unused param.
+   * @param array $metabox Array containing id, title, callback, and args elements.
+   */
+  public function meta_box_error_path_render($unused = NULL, $metabox) {
+
+    global $civicrm_root;
+
+    // Include template file.
+    include CIVICRM_PLUGIN_DIR . 'assets/templates/metaboxes/metabox.error.path.php';
+
+  }
+
+}

--- a/includes/admin-pages/civicrm.page.integration.php
+++ b/includes/admin-pages/civicrm.page.integration.php
@@ -120,7 +120,7 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
   public function add_menu_items() {
 
     // Bail if not fully installed.
-    if (!CIVICRM_INSTALLED) {
+    if (!$this->civi->initialize()) {
       return;
     }
 

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -121,6 +121,10 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
    */
   public function add_menu_items() {
 
+    if (!$this->civi->initialize()) {
+      return;
+    }
+
     // Get access capability.
     $capability = $this->access_capability();
 


### PR DESCRIPTION
Overview
----------------------------------------
Rewrites the error checking that the WordPress plugin performs and fails gracefully instead of throwing fatal errors and making WordPress inoperable. Introduces a "CiviCRM Troubleshooting" page to help diagnose and fix problems.

Before
----------------------------------------
When the PHP version was less than the required version, CiviCRM would call `wp_die()` and make WordPress inoperable. Other error checking during `initialize` was either never performed or never acted upon.

After
----------------------------------------
New framework for handling errors that provides a configurable "CiviCRM Troubleshooting" page to help diagnose and fix problems when they are encountered.

The plugin header `Requires PHP:` parameter prevents installation when an insufficient PHP version is detected. However, this does not handle the same situation after a CiviCRM upgrade. This Troubleshooting page is now shown instead of CiviCRM's admin UI:

<img width="1440" alt="Screenshot 2021-06-18 at 15 12 48" src="https://user-images.githubusercontent.com/726936/122578850-329a5880-d04c-11eb-97f8-5e3905d640ed.png">

It's more difficult to handle broken file systems - but, where possible, the following Troubleshooting page is now shown instead of CiviCRM's admin UI. (Try renaming `civicrm/CRM/Core/Config.php` to `civicrm/CRM/Core/Config.php.bak` to see this page)

<img width="1440" alt="Screenshot 2021-06-18 at 15 11 24" src="https://user-images.githubusercontent.com/726936/122579728-1e0a9000-d04d-11eb-9db0-04ec07b15dbc.png">

Whilst not complete in its coverage of possible errors, this code can be developed to be more comprehensive in future. The major improvement is that WordPress does not stop functioning whilst problems are attended to.