### PR TITLE
revert #240 Remove Base Page content filter once it has been used

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -522,9 +522,6 @@ class CiviCRM_For_WordPress_Basepage {
    */
   public function basepage_render() {
 
-    // We no longer need this filter, so remove it.
-    remove_filter('the_content', [$this, 'basepage_render']);
-
     // Hand back our base page markup.
     return $this->basepage_markup;
 


### PR DESCRIPTION
See https://lab.civicrm.org/dev/wordpress/-/issues/112 and https://lab.civicrm.org/dev/wordpress/-/issues/107

Getting redirect loop in some cases, and a confirmation page just showing the shortcoden in all others.

Suggest revert.

This should also be backported to ESR. 

ping @eileenmcnaughton   