### PR TITLE
Introduce "Shortcode Display Mode" setting and functionality

### DIFF
--- a/assets/js/civicrm.options.js
+++ b/assets/js/civicrm.options.js
@@ -165,11 +165,14 @@
 
       // Assign properties.
       me.basepage_submit = $('#civicrm_basepage_submit');
+      me.shortcode_submit = $('#civicrm_shortcode_submit');
       me.email_submit = $('#civicrm_email_submit');
       me.cache_submit = $('#civicrm_cache_submit');
       me.basepage_select = $('#page_id');
+      me.shortcode_select = $('#shortcode_mode');
       me.email_select = $('#sync_email');
       me.basepage_selected = me.basepage_select.val();
+      me.shortcode_selected = me.shortcode_select.val();
       me.email_selected = me.email_select.val();
 
       // Set status of Base Page submit button.
@@ -177,6 +180,10 @@
       if (me.basepage_select !== '') {
         me.basepage_submit.val(text);
       }
+
+      // Set status of Shortcode Mode submit button.
+      me.shortcode_submit.val(text);
+      me.shortcode_submit.prop('disabled', true);
 
       // Set status of Email Sync submit button.
       me.email_submit.val(text);
@@ -224,7 +231,29 @@
       });
 
       /**
-       * Add an onchange event listener to the "Basepage" section select.
+       * Add an onchange event listener to the "Shortcode Mode" section select.
+       *
+       * @param {Object} event The event object.
+       */
+      me.shortcode_select.on('change', function(event) {
+
+        var text;
+
+        // Enable/disable submit button.
+        if (me.shortcode_select.val() == me.shortcode_selected) {
+          text = CiviCRM_Options_Settings.get_localisation('saved');
+          me.shortcode_submit.val(text);
+          me.shortcode_submit.prop('disabled', true);
+        } else {
+          text = CiviCRM_Options_Settings.get_localisation('update');
+          me.shortcode_submit.val(text);
+          me.shortcode_submit.prop('disabled', false);
+        }
+
+      });
+
+      /**
+       * Add an onchange event listener to the "Email Sync" section select.
        *
        * @param {Object} event The event object.
        */
@@ -270,6 +299,34 @@
 
         // Submit setting to server.
         me.send('civicrm_basepage', value, ajax_nonce);
+
+      });
+
+      /**
+       * Add a click event listener to the "Shortcode Mode" section submit button.
+       *
+       * @param {Object} event The event object.
+       */
+      me.shortcode_submit.on('click', function(event) {
+
+        // Define vars.
+        var value = me.shortcode_select.val(),
+            ajax_nonce = me.shortcode_submit.data('security'),
+            saving = CiviCRM_Options_Settings.get_localisation('saving');
+
+        // Prevent form submission.
+        if (event.preventDefault) {
+          event.preventDefault();
+        }
+
+        // Modify button and select, then show spinner.
+        me.shortcode_submit.val(saving);
+        me.shortcode_submit.prop('disabled', true);
+        me.shortcode_select.prop('disabled', true);
+        $(this).next('.spinner').css('visibility', 'visible');
+
+        // Submit setting to server.
+        me.send('civicrm_shortcode', value, ajax_nonce);
 
       });
 
@@ -414,6 +471,15 @@
           }
           me.basepage_selected = data.result;
 
+        } else if (data.section == 'shortcode') {
+
+          // Shortcode Mode section.
+          me.shortcode_submit.val(saved);
+          me.shortcode_submit.next('.spinner').css('visibility', 'hidden');
+          me.shortcode_select.val(data.result);
+          me.shortcode_selected = data.result;
+          me.shortcode_select.prop('disabled', false);
+
         } else if (data.section == 'email_sync') {
 
           // Email Sync section.
@@ -449,6 +515,30 @@
           $('.basepage_notice p').html(data.notice);
           $('.basepage_feedback').html(data.message);
           me.basepage_selected = data.result;
+
+        } else if (data.section == 'shortcode') {
+
+          // Shortcode Mode section.
+          me.shortcode_submit.val(update);
+          me.shortcode_submit.next('.spinner').css('visibility', 'hidden');
+          me.shortcode_select.val(data.result);
+          me.shortcode_select.prop('disabled', false);
+          $('.shortcode_notice').show();
+          $('.shortcode_notice p').html(data.notice);
+          $('.shortcode_feedback').html(data.message);
+          me.shortcode_selected = data.result;
+
+        } else if (data.section == 'email_sync') {
+
+          // Email Sync section.
+          me.email_submit.val(update);
+          me.email_submit.next('.spinner').css('visibility', 'hidden');
+          me.email_select.val(data.result);
+          me.email_select.prop('disabled', false);
+          $('.email_notice').show();
+          $('.email_notice p').html(data.notice);
+          $('.email_feedback').html(data.message);
+          me.email_selected = data.result;
 
         } else if (data.section == 'clear_caches') {
 

--- a/assets/templates/metaboxes/metabox.options.email.php
+++ b/assets/templates/metaboxes/metabox.options.email.php
@@ -28,6 +28,10 @@
 do_action('civicrm/metabox/email_sync/pre');
 
 ?>
+<div class="email_notice notice notice-error inline" style="background-color: #f7f7f7; display: none;">
+  <p></p>
+</div>
+
 <p><?php _e('When a WordPress User updates their Email, CiviCRM will automatically update the Primary Email of their linked Contact record. This setting lets you choose whether the reverse update should happen - i.e. if the Primary Email of a Contact that has a linked WordPress User is updated, do you want CiviCRM to update the WordPress User Email?', 'civicrm'); ?></p>
 
 <label for="sync_email" class="screen-reader-text"><?php _e('Sync Emails', 'civicrm'); ?></label>

--- a/assets/templates/metaboxes/metabox.options.shortcode.php
+++ b/assets/templates/metaboxes/metabox.options.shortcode.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+?><!-- assets/templates/metaboxes/metabox.options.shortcode.php -->
+<?php
+
+/**
+ * Before Shortcode section.
+ *
+ * @since 5.44
+ */
+do_action('civicrm/metabox/shortcode/pre');
+
+?>
+<div class="shortcode_notice notice notice-error inline" style="background-color: #f7f7f7; display: none;">
+  <p></p>
+</div>
+
+<p><?php _e('When a CiviCRM Shortcode is embedded in a Post/Page without "hijack" being set, it is shown embedded in the content in "Shortcode Mode". If any action is taken via the Shortcode, a query string is appended to the URL and the Post/Page is shown in "Base Page Mode" and the title and content are overwritten. Choose to keep this legacy behaviour or move to the new "Remain in Shortcode Mode" behaviour.', 'civicrm'); ?></p>
+
+<label for="shortcode_mode" class="screen-reader-text"><?php _e('Display Mode', 'civicrm'); ?></label>
+<select name="shortcode_mode" id="shortcode_mode">
+  <option value="modern"<?php echo $selected_modern; ?>><?php esc_html_e('Remain in Shortcode Mode', 'civicrm'); ?></option>
+  <option value="legacy"<?php echo $selected_legacy; ?>><?php esc_html_e('Legacy Base Page Mode', 'civicrm'); ?></option>
+</select>
+
+<p class="submit">
+  <?php submit_button(esc_html__('Saved', 'civicrm'), 'primary hide-if-no-js', 'civicrm_shortcode_submit', FALSE, $options_ajax); ?>
+  <?php submit_button(esc_html__('Update', 'civicrm'), 'primary hide-if-js', 'civicrm_shortcode_post_submit', FALSE, $options_post); ?>
+  <span class="spinner"></span>
+</p>
+<br class="clear">
+<?php
+
+/**
+ * After Shortcode section.
+ *
+ * @since 5.44
+ */
+do_action('civicrm/metabox/shortcode/post');

--- a/civicrm.php
+++ b/civicrm.php
@@ -692,7 +692,7 @@ class CiviCRM_For_WordPress {
     // Store context.
     $this->civicrm_in_wordpress_set();
 
-    // When embedded via wpBasePage or AJAX call.
+    // When the CiviCRM query var is detected.
     if ($this->civicrm_in_wordpress()) {
 
       /*
@@ -718,19 +718,10 @@ class CiviCRM_For_WordPress {
 
       }
 
-      // Set context.
-      $this->civicrm_context_set('basepage');
-
-      // If we get here, we must be in a "wpBasePage" context.
-      $this->basepage->register_hooks();
-      return;
-
     }
 
-    // Set context.
-    $this->civicrm_context_set('shortcode');
-
-    // That leaves us with handling shortcodes, should they exist.
+    // Let the classes decide how to handle other requests.
+    $this->basepage->register_hooks();
     $this->shortcodes->register_hooks();
 
   }

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -901,4 +901,39 @@ class CiviCRM_For_WordPress_Admin {
 
   }
 
+  /**
+   * Gets the CiviCRM Shortcode Mode.
+   *
+   * Defaults to "legacy" to preserve existing behaviour.
+   *
+   * @since 5.44
+   *
+   * @return string $shortcode_mode The Shortcode Mode: either 'legacy' or 'modern'.
+   */
+  public function get_shortcode_mode() {
+    return get_option('civicrm_shortcode_mode', 'legacy');
+  }
+
+  /**
+   * Sets the CiviCRM Shortcode Mode.
+   *
+   * @since 5.44
+   *
+   * @param string $shortcode_mode The Shortcode Mode: either 'legacy' or 'modern'.
+   */
+  public function set_shortcode_mode($shortcode_mode) {
+    update_option('civicrm_shortcode_mode', $shortcode_mode);
+  }
+
+  /**
+   * Gets the array of CiviCRM Shortcode Modes.
+   *
+   * @since 5.44
+   *
+   * @return array $shortcode_modes The array of Shortcode Modes.
+   */
+  public function get_shortcode_modes() {
+    return ['legacy', 'modern'];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Replaces #239. Discussion and screenshots [on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/90).

Before
----------------------------------------
Shortcodes that had an "action" taken on them render as if they were on the Base Page.

After
----------------------------------------
Introduces a new metabox with a "Shortcode Display Mode" setting.

![civicrm-shortcode-mode-metabox](https://user-images.githubusercontent.com/726936/137463079-2d6de5d0-aedc-4b9e-ad29-400b777f3245.png)

Depending on the chosen setting:

* Shortcodes that had an "action" taken on them render as if they were on the Base Page.
* Shortcodes that had an "action" taken on them render in the context that they were embedded in.

Technical Details
----------------------------------------
Please refer to Lab and previous PR.

Comments
----------------------------------------
I think this PR avoids the need for documentation and for the upgrade notice in Core (which caused the previous PR to stall) because the default remains unchanged whilst "better Shortcode handling" can be implemented via the CiviCRM Settings screen for those who wish to use it.