### PR TITLE
Prevent fatal error when the "the_title" filter has only one param

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -628,7 +628,12 @@ class CiviCRM_For_WordPress_Shortcodes {
    * @param int $post_id The numeric ID of the WordPress post.
    * @return string $title The overridden title.
    */
-  public function get_title($title, $post_id) {
+  public function get_title($title, $post_id = 0) {
+
+    // Bail if there is no Post ID.
+    if (empty($post_id)) {
+      return $title;
+    }
 
     // Is this the post?
     if (!array_key_exists($post_id, $this->shortcode_markup)) {


### PR DESCRIPTION
Overview
----------------------------------------
The "Give" plugin [calls "the_title" filter with only one param](https://github.com/impress-org/givewp/blob/775c659589fe106d06b20b9a5fa12a2b19ca9770/src/Views/IframeContentView.php#L102) and this produces a fatal error in `CiviCRM_For_WordPress_Shortcodes::get_title()`.

Before
----------------------------------------
Fatal error.

After
----------------------------------------
No fatal error.