### PR TITLE
CiviCRM WordPress shortcode remove the display of default text and instead just return blank if the shortcode cannot be rendered.

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -402,7 +402,7 @@ class CiviCRM_For_WordPress_Shortcodes {
 
     // Get pathless markup from filter callback.
     if (empty($args['q'])) {
-      $markup = '<p>' . __('The Shortcode could not be handled. It could be malformed or used incorrectly.', 'civicrm') . '</p>';
+      $markup = '';
       /** This filter is documented in includes/civicrm-shortcodes.php */
       return apply_filters('civicrm_shortcode_get_markup', $markup, $atts, $args, 'multiple');
     }


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM WordPress shortcode remove the display of default text and instead just return blank if the shortcode cannot be rendered.

Before
----------------------------------------
The message "Do not know how to handle this shortcode" or "The Shortcode could not be handled. It could be malformed or used incorrectly" can be shown publicly on a website (as well as to logged in users) if any of these conditions are true:

1. If the user does not have the required permission to view the CiviCRM component, for example: no permission to view a specific afform page
2. CiviCRM shortcode returns without setting a value
3. CiviCRM shortcode is invalid, parameters are incorrect or missing

After
----------------------------------------
Shortcode returns blank. No error text is shown.

Technical Details
----------------------------------------


Comments
----------------------------------------
It would be preferred that error messages are not shown on the public website and if the CiviCRM shortcode has been mis-configured then this should be picked up by the CiviCRM Admin and/or CiviCRM Developer / Web Developer when testing the page.

It might be beneficial to add throw an exception and log an error when the CiviCRM shortcode returns an empty value. But that's beyond the scope of this PR.

Agileware Ref: CIVICRM-1896 