### PR TITLE
HookTest - Fix execution on PHP 8

### DIFF
--- a/tests/phpunit/CiviWP/HookTest.php
+++ b/tests/phpunit/CiviWP/HookTest.php
@@ -19,7 +19,7 @@ namespace CiviWP {
         'foo' => 123,
       );
       $this->assertNotEquals($arg2['foo'], 456);
-      $this->assertNotEquals($arg2['hook_was_called'], 1);
+      $this->assertFalse(isset($arg2['hook_was_called']));
       \CRM_Utils_Hook::singleton()
         ->invoke(
           2,


### PR DESCRIPTION
@seamuslee001 This should address the failure demonstrated by #265.

Before
------

Test fails on PHP 8

```
CiviWP\HookTest::testFoo
Undefined array key "hook_was_called"

/home/jenkins/bknix-dfl/build/wp-265-47vsb/web/wp-content/plugins/civicrm/tests/phpunit/CiviWP/HookTest.php:22
```

After
-----

Test passes

Comments
--------

This is a superficial change - the assertion in question is supposed to validate the starting circumstance (asserting that the hook has not yet run). This is just a cleaner assertion that the hook has not yet run.

