### PR TITLE
(Backport) HookTest - Fix execution on PHP 8

### DIFF
--- a/tests/phpunit/CiviWP/HookTest.php
+++ b/tests/phpunit/CiviWP/HookTest.php
@@ -19,7 +19,7 @@ namespace CiviWP {
         'foo' => 123,
       );
       $this->assertNotEquals($arg2['foo'], 456);
-      $this->assertNotEquals($arg2['hook_was_called'], 1);
+      $this->assertFalse(isset($arg2['hook_was_called']));
       \CRM_Utils_Hook::singleton()
         ->invoke(
           2,


### PR DESCRIPTION
Backport #266 from 5.46.alpha1 to 5.45.beta1 (RC).