### PR TITLE
wp-cli/civicrm.php - Add 'civicrm pipe' subcommand

### DIFF
--- a/wp-cli/civicrm.php
+++ b/wp-cli/civicrm.php
@@ -47,6 +47,11 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
      * ===============
      * Run the CiviMember UpdateMembershipRecord cron (civicrm member-records).
      *
+     * wp civicrm pipe <connection-flags>
+     * ==================
+     * Start a Civi::pipe session (JSON-RPC 2.0)
+     * See https://docs.civicrm.org/dev/en/latest/framework/pipe#flags
+     *
      * wp civicrm process-mail-queue
      * ===============
      * Process pending CiviMail mailing jobs.
@@ -122,6 +127,7 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
         'disable-debug'      => 'disableDebug',
         'install'            => 'install',
         'member-records'     => 'memberRecords',
+        'pipe'               => 'pipe',
         'process-mail-queue' => 'processMailQueue',
         'rest'               => 'rest',
         'restore'            => 'restore',
@@ -457,6 +463,20 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
 
       }
 
+    }
+
+    private function pipe() {
+      civicrm_initialize();
+      if (!is_callable(['Civi', 'pipe'])) {
+        return WP_CLI::error('This version of CiviCRM does not include Civi::pipe() support.');
+      }
+
+      if (!empty($this->args[1])) {
+        Civi::pipe($this->args[1]);
+      }
+      else {
+        Civi::pipe();
+      }
     }
 
     /**


### PR DESCRIPTION
Add support for subcommand `wp civicrm pipe`

Complements https://github.com/civicrm/civicrm-core/pull/22262. Similar to https://github.com/civicrm/cv/pull/110.

Before
------------

Longer commands:

```bash
wp eval 'civicrm_initialize(); Civi::pipe();'
wp eval 'civicrm_initialize(); Civi::pipe("vlu");'
````

After
-------------

Shorter commands:

```bash
wp civicrm pipe
wp civicrm pipe vlu
```

Comment
--------------

If the command is successful, it will show a welcome/header line, e.g.

```javascript
{"Civi::pipe":{"v":"5.47.alpha1","l":["nologin"],"u":"untrusted"}}
```

You may then send JSON-RPC 2.0 requests, e.g.

```javascript
// Send request for `echo("hello world")`
{"jsonrpc":"2.0","method":"echo","params":["hello world"],"id":null}
// Receive response "hello world"
{"jsonrpc":"2.0","result":["hello world"],"id":null}
```
