### PR TITLE
Fixes fatal error - function doesn't exist

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -322,7 +322,7 @@ class CiviCRM_For_WordPress_Basepage {
     }
 
     // Bail if this is a Favicon request.
-    if (is_favicon()) {
+    if (function_exists('is_favicon') && is_favicon()) {
       return;
     }
 

--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -109,7 +109,7 @@ class CiviCRM_For_WordPress_Shortcodes {
     }
 
     // Bail if this is a Favicon request.
-    if (is_favicon()) {
+    if (function_exists('is_favicon') && is_favicon()) {
       return;
     }
 


### PR DESCRIPTION
As per https://developer.wordpress.org/reference/functions/is_favicon/ this function was only added in 5.4.0
meaning CiviCRM now breaks if installed on a site running Wordpress < 5.4.0

Overview
----------------------------------------
Checks function exists before calling.

Before
----------------------------------------
Fatal error

After
----------------------------------------
You should probably  upgrade your Wordpress site but if you are stranded on an old version due to plugin/theme incompatibilities at least you don't have a fatal error!

Technical Details
