### PR TITLE
Always return boolean from initialize method

### DIFF
--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -403,7 +403,7 @@ class CiviCRM_For_WordPress_Admin {
     if ($error == FALSE) {
       $this->error_flag = 'settings-include';
       $initialized = FALSE;
-      return;
+      return FALSE;
     }
 
     // Initialize the Class Loader.
@@ -417,7 +417,7 @@ class CiviCRM_For_WordPress_Admin {
     if (!file_exists($civicrm_root . 'CRM/Core/Config.php')) {
       $this->error_flag = 'config-missing';
       $initialized = FALSE;
-      return;
+      return FALSE;
     }
 
     // Include config file - returns int(1) on success.


### PR DESCRIPTION
Overview
----------------------------------------
Makes sure `CiviCRM_For_WordPress_Admin::initialize()` always returns a boolean as declred in the docblock.

Before
----------------------------------------
`CiviCRM_For_WordPress_Admin::initialize()` currently returns a mix of `TRUE`, `FALSE` and `NULL`.

After
----------------------------------------
`CiviCRM_For_WordPress_Admin::initialize()` returns either `TRUE` or `FALSE`.