### PR TITLE
Raise priority of Base Page `the_content` callback

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -470,7 +470,7 @@ class CiviCRM_For_WordPress_Basepage {
       add_action('wp', [$this->civi, 'front_end_page_load'], 100);
 
       // Include this content when Base Page is rendered.
-      add_filter('the_content', [$this, 'basepage_render']);
+      add_filter('the_content', [$this, 'basepage_render'], 21);
 
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
While investigating [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/131), I discovered that WordPress "block themes" do not render content via `the_content()` function any more, but do so via a function ported from Gutenberg, where many of the functions that are hooked into `the_content` filter are called directly.

In anticipation of something being done about these direct calls, it seems sensible to me to call the method that overwrites the Base Page content after _all_ core default filters have been applied. We may wish to consider making it higher still.

Before
----------------------------------------
`basepage_render()` was called with the default priority.

After
----------------------------------------
`basepage_render()` was called with priority `21`, i.e. after the final default filter `convert_smilies`.

Technical Details
----------------------------------------
There aren't any functional changes in this PR - however it is possible that other plugins may need to adjust the priority of their `the_content` callbacks if they relate in any way to `basepage_render()`. I think it's unlikely that there will be many (if any) affected, though I did post [an example of one](https://lab.civicrm.org/dev/wordpress/-/issues/127#note_83439) earlier today which has a suitable priority set.