### PR TITLE
[REF][PHP8.1] dev/core#3181 Apply fixes for passing NULL into string …

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1358,8 +1358,8 @@ class CiviCRM_For_WordPress {
     if (CRM_Utils_Array::value('HTTP_X_REQUESTED_WITH', $_SERVER) == 'XMLHttpRequest'
         || ($argdata['args'][0] == 'civicrm' && in_array($argdata['args'][1], ['ajax', 'file']))
         || !empty($_REQUEST['snippet'])
-        || strpos($argdata['argString'], 'civicrm/event/ical') === 0 && empty($html)
-        || strpos($argdata['argString'], 'civicrm/contact/imagefile') === 0
+        || strpos($argdata['argString'] ?? '', 'civicrm/event/ical') === 0 && empty($html)
+        || strpos($argdata['argString'] ?? '', 'civicrm/contact/imagefile') === 0
     ) {
       $return = FALSE;
     }


### PR DESCRIPTION
…function that is deprecated in PHP8.1

Overview
----------------------------------------
Fixes a couple of notice errors that were reported here https://lab.civicrm.org/dev/core/-/issues/3181 

Before
----------------------------------------
Notice errors generated in PHP8.1

After
----------------------------------------
Notice errors gone

ping @demeritcowboy @eileenmcnaughton @kcristiano @christianwach 