### PR TITLE
dev/core#3991 Bump minimum PHP version to 7.3.0

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -4,7 +4,7 @@
  * Description: CiviCRM - Growing and Sustaining Relationships
  * Version: 4.7
  * Requires at least: 4.9
- * Requires PHP:      7.2
+ * Requires PHP:      7.3
  * Author: CiviCRM LLC
  * Author URI: https://civicrm.org/
  * Plugin URI: https://docs.civicrm.org/sysadmin/en/latest/install/wordpress/
@@ -65,7 +65,7 @@ if (!defined('CIVICRM_PLUGIN_DIR')) {
  * @see CiviWP\PhpVersionTest::testConstantMatch()
  */
 if (!defined('CIVICRM_WP_PHP_MINIMUM')) {
-  define('CIVICRM_WP_PHP_MINIMUM', '7.2.0');
+  define('CIVICRM_WP_PHP_MINIMUM', '7.3.0');
 }
 
 /*

--- a/wp-rest/README.md
+++ b/wp-rest/README.md
@@ -4,7 +4,7 @@ This code exposes CiviCRM's [extern](https://github.com/civicrm/civicrm-core/tre
 
 ### Requirements
 
--   PHP 7.2+
+-   PHP 7.3+
 -   WordPress 4.7+
 -   CiviCRM to be installed and activated.
 


### PR DESCRIPTION
Overview
----------------------------------------
As per the ticket this bumps the Minimum required PHP version to be 7.3.0

Before
----------------------------------------
Minimum is 7.2.0

After
----------------------------------------
Minimum is 7.3.0

ping @totten @colemanw @eileenmcnaughton @kcristiano 