### PR TITLE
Use custom actions for rendering admin pages

### DIFF
--- a/includes/admin-pages/civicrm.page.error.php
+++ b/includes/admin-pages/civicrm.page.error.php
@@ -66,7 +66,7 @@ class CiviCRM_For_WordPress_Admin_Page_Error {
     $this->add_menu_items($logo, $position);
 
     // Add our meta boxes.
-    add_action('add_meta_boxes', [$this, 'meta_boxes_error_add']);
+    add_action('civicrm/page/error/add_meta_boxes', [$this, 'meta_boxes_error_add']);
 
   }
 
@@ -177,7 +177,7 @@ class CiviCRM_For_WordPress_Admin_Page_Error {
      *
      * @param str $screen_id The ID of the current screen.
      */
-    do_action('add_meta_boxes', $screen->id, NULL);
+    do_action('civicrm/page/error/add_meta_boxes', $screen->id);
 
     // Grab columns.
     $columns = (1 == $screen->get_columns() ? '1' : '2');

--- a/includes/admin-pages/civicrm.page.integration.php
+++ b/includes/admin-pages/civicrm.page.integration.php
@@ -89,7 +89,7 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
     add_action('admin_menu', [$this, 'add_menu_items'], 9);
 
     // Add our meta boxes.
-    add_action('add_meta_boxes', [$this, 'meta_boxes_integration_add']);
+    add_action('civicrm/page/integration/add_meta_boxes', [$this, 'meta_boxes_integration_add']);
 
   }
 
@@ -201,7 +201,7 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
      *
      * @param str $screen_id The ID of the current screen.
      */
-    do_action('add_meta_boxes', $screen->id, NULL);
+    do_action('civicrm/page/integration/add_meta_boxes', $screen->id);
 
     // Get the column CSS class.
     $columns = absint($screen->get_columns());

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -86,7 +86,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     add_action('admin_menu', [$this, 'add_menu_items'], 9);
 
     // Add our meta boxes.
-    add_action('add_meta_boxes', [$this, 'meta_boxes_options_add']);
+    add_action('civicrm/page/options/add_meta_boxes', [$this, 'meta_boxes_options_add']);
 
     // Add AJAX handlers.
     add_action('wp_ajax_civicrm_basepage', [$this, 'ajax_save_basepage']);
@@ -240,7 +240,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
      *
      * @param str $screen_id The ID of the current screen.
      */
-    do_action('add_meta_boxes', $screen->id, NULL);
+    do_action('civicrm/page/options/add_meta_boxes', $screen->id);
 
     // Get the column CSS class.
     $columns = absint($screen->get_columns());


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/139).

Before
----------------------------------------
PHP warnings from plugins such as:

```
PHP Warning:  Attempt to read property "ID" on null in /path/to/httpdocs/wp-content/plugins/acf-extended/includes/module-post.php on line 39
```

After
----------------------------------------
No PHP warnings.