### PR TITLE
update WP Version tested to and CV Stable version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: needle
 Tags: civicrm, crm
 Requires at least: 4.9
-Tested up to: 6.1
-Stable tag: 5.60
+Tested up to: 6.2
+Stable tag: 5.61
 License: AGPL3
 License URI: http://www.gnu.org/licenses/agpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: needle
 Tags: civicrm, crm
 Requires at least: 4.9
 Tested up to: 6.2
-Stable tag: 5.61
+Stable tag: 5.63
 License: AGPL3
 License URI: http://www.gnu.org/licenses/agpl-3.0.html
 


### PR DESCRIPTION
Overview
----------------------------------------
Update WP Version Tested to and Stable CiviCRM version 
Before
----------------------------------------
Reports WP 6.1 and CiviCRM 5.60

After
----------------------------------------
Reports WP 6.2 (current) and CiviCRM 5.61

