### PR TITLE
5.62 - Update call to renamed mailing BAO

### DIFF
--- a/wp-rest/Controller/Url.php
+++ b/wp-rest/Controller/Url.php
@@ -55,7 +55,7 @@ class Url extends Base {
     $params = apply_filters('civi_wp_rest/controller/url/params', $this->get_formatted_params($request), $request);
 
     // Track URL.
-    $url = \CRM_Mailing_Event_BAO_MailingEventClickThrough::track($params['queue_id'], $params['url_id']);
+    $url = \CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track($params['queue_id'], $params['url_id']);
 
     /**
      * Filter URL.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/4363 (backport for 5.62)

Regressed due to https://github.com/civicrm/civicrm-wordpress/pull/285 and https://github.com/civicrm/civicrm-core/pull/26016

Before
----------------------------------------
Crash when using trackable url

After
----------------------------------------
Fixed