### PR TITLE
Fix warning caused by passing null to strpos

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1423,11 +1423,11 @@ class CiviCRM_For_WordPress {
    *
    * @since 4.6
    *
-   * @return array $argdata Array containing request arguments and request string.
+   * @return array{args: array, argString: string}
    */
   public function get_request_args() {
 
-    $argString = NULL;
+    $argString = '';
     $args = [];
 
     // Get path from query vars.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bunch of PHP warnings when you visit the CiviCRM home page (dashboard) without a `q=` argument in the URL.

Before
----------------------------------------
Home page looks like this:
![image](https://github.com/civicrm/civicrm-wordpress/assets/2874912/d22158ba-5b85-4c23-adf1-02a7ba2e0330)



After
----------------------------------------
Home page looks like this:
![image](https://github.com/civicrm/civicrm-wordpress/assets/2874912/62fef979-5ae7-4d31-befc-78da69b95db6)


Technical Details
----------
There was no reason to return NULL in a variable that was supposed to be a string.