### PR TITLE
Compatibility framework including URL support for Polylang

### DIFF
--- a/includes/civicrm.compat.php
+++ b/includes/civicrm.compat.php
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Define CiviCRM_For_WordPress_Compat Class.
+ * Compatibility class.
  *
  * @since 5.24
  */
@@ -37,6 +37,30 @@ class CiviCRM_For_WordPress_Compat {
   public $civi;
 
   /**
+   * @var object
+   * Miscellaneous plugin compatibility object.
+   * @since 5.66
+   * @access public
+   */
+  public $misc;
+
+  /**
+   * @var object
+   * Polylang compatibility object.
+   * @since 5.66
+   * @access public
+   */
+  public $polylang;
+
+  /**
+   * @var object
+   * WPML compatibility object.
+   * @since 5.66
+   * @access public
+   */
+  public $wpml;
+
+  /**
    * Instance constructor.
    *
    * @since 5.24
@@ -46,123 +70,38 @@ class CiviCRM_For_WordPress_Compat {
     // Store reference to CiviCRM plugin object.
     $this->civi = civi_wp();
 
-    // Register plugin compatibility hooks.
-    $this->register_hooks();
+    // Includes and setup.
+    $this->include_files();
+    $this->setup_objects();
 
   }
 
   /**
-   * Register plugin compatibility hooks.
+   * Include files.
    *
-   * This is called via the constructor during the "plugins_loaded" action which
-   * is much earlier that CiviCRM's own internal hooks. The reason for this is
-   * that compability may need callbacks for events that fire well before "init"
-   * which is when CiviCRM begins to load.
-   *
-   * @since 5.24
+   * @since 5.66
    */
-  public function register_hooks() {
+  public function include_files() {
 
-    // Bail if CiviCRM not installed yet.
-    if (!CIVICRM_INSTALLED) {
-      return;
-    }
-
-    // Support Clean URLs when Polylang is active.
-    add_action('civicrm_after_rewrite_rules', [$this, 'rewrite_rules_polylang'], 10, 2);
-
-    // Prevent AIOSEO from stomping on CiviCRM Shortcodes.
-    add_filter('aioseo_conflicting_shortcodes', [$this, 'aioseo_resolve_conflict']);
+    // Include plugin compatibility files.
+    include_once CIVICRM_PLUGIN_DIR . 'includes/compatibility/civicrm.misc.php';
+    include_once CIVICRM_PLUGIN_DIR . 'includes/compatibility/civicrm.polylang.php';
+    include_once CIVICRM_PLUGIN_DIR . 'includes/compatibility/civicrm.wpml.php';
 
   }
 
   /**
-   * Support Polylang.
+   * Instantiate objects.
    *
-   * @since 5.24
-   *
-   * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
-   * @param WP_Post $basepage The Base Page post object.
+   * @since 5.66
    */
-  public function rewrite_rules_polylang($flush_rewrite_rules, $basepage) {
+  public function setup_objects() {
 
-    // Bail if Polylang is not present.
-    if (!function_exists('pll_languages_list')) {
-      return;
-    }
+    // Instantiate plugin compatibility objects.
+    $this->misc = new CiviCRM_For_WordPress_Compat_Misc();
+    $this->polylang = new CiviCRM_For_WordPress_Compat_Polylang();
+    $this->wpml = new CiviCRM_For_WordPress_Compat_WPML();
 
-    /*
-     * Collect all rewrite rules into an array.
-     *
-     * Because the array of specific Post IDs is added *after* the array of
-     * paths for the Base Page ID, those specific rewrite rules will "win" over
-     * the more general Base Page rules.
-     */
-    $collected_rewrites = [];
-
-    // Support prefixes for a single Base Page.
-    $basepage_url = get_permalink($basepage->ID);
-    $basepage_raw_url = PLL()->links_model->remove_language_from_link($basepage_url);
-    $language_slugs = pll_languages_list();
-    foreach ($language_slugs as $slug) {
-      $language = PLL()->model->get_language($slug);
-      $language_url = PLL()->links_model->add_language_to_link($basepage_raw_url, $language);
-      $parsed_url = wp_parse_url($language_url, PHP_URL_PATH);
-      $regex_path = substr($parsed_url, 1);
-      $collected_rewrites[$basepage->ID][] = $regex_path;
-      $post_id = pll_get_post($basepage->ID, $slug);
-      if (!empty($post_id)) {
-        $collected_rewrites[$post_id][] = $regex_path;
-      }
-    };
-
-    // Support prefixes for Base Pages in multiple languages.
-    foreach ($language_slugs as $slug) {
-      $post_id = pll_get_post($basepage->ID, $slug);
-      if (empty($post_id)) {
-        continue;
-      }
-      $url = get_permalink($post_id);
-      $parsed_url = wp_parse_url($url, PHP_URL_PATH);
-      $regex_path = substr($parsed_url, 1);
-      $collected_rewrites[$basepage->ID][] = $regex_path;
-      $collected_rewrites[$post_id][] = $regex_path;
-    };
-
-    // Make collection unique and add remaining rewrite rules.
-    $rewrites = array_map('array_unique', $collected_rewrites);
-    if (!empty($rewrites)) {
-      foreach ($rewrites as $post_id => $rewrite) {
-        foreach ($rewrite as $path) {
-          add_rewrite_rule(
-            '^' . $path . '([^?]*)?',
-            'index.php?page_id=' . $post_id . '&civiwp=CiviCRM&q=civicrm%2F$matches[1]',
-            'top'
-          );
-        }
-      }
-    }
-
-    // Maybe force flush.
-    if ($flush_rewrite_rules) {
-      flush_rewrite_rules();
-    }
-
-  }
-
-  /**
-   * Fixes AIOSEO's attempt to modify Shortcodes.
-   *
-   * @see https://civicrm.stackexchange.com/questions/40765/wp-all-in-one-seo-plugin-conflict
-   *
-   * @since 5.45
-   *
-   * @param array $conflicting_shortcodes The existing AIOSEO Conflicting Shortcodes array.
-   * @return array $conflicting_shortcodes The modified AIOSEO Conflicting Shortcodes array.
-   */
-  public function aioseo_resolve_conflict($conflicting_shortcodes) {
-    $conflicting_shortcodes['CiviCRM'] = 'civicrm';
-    return $conflicting_shortcodes;
   }
 
 }

--- a/includes/compatibility/civicrm.misc.php
+++ b/includes/compatibility/civicrm.misc.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+/**
+ * Miscellaneous plugin compatibility class.
+ *
+ * @since 5.24
+ */
+class CiviCRM_For_WordPress_Compat_Misc {
+
+  /**
+   * @var object
+   * Plugin object reference.
+   * @since 5.24
+   * @access public
+   */
+  public $civi;
+
+  /**
+   * Instance constructor.
+   *
+   * @since 5.24
+   */
+  public function __construct() {
+
+    // Store reference to CiviCRM plugin object.
+    $this->civi = civi_wp();
+
+    // Register plugin compatibility hooks.
+    $this->register_hooks();
+
+  }
+
+  /**
+   * Register plugin compatibility hooks.
+   *
+   * This is called via the constructor during the "plugins_loaded" action which
+   * is much earlier that CiviCRM's own internal hooks. The reason for this is
+   * that compability may need callbacks for events that fire well before "init"
+   * which is when CiviCRM begins to load.
+   *
+   * @since 5.24
+   */
+  public function register_hooks() {
+
+    // Bail if CiviCRM not installed yet.
+    if (!CIVICRM_INSTALLED) {
+      return;
+    }
+
+    // Register Base Page callbacks.
+    add_action('civicrm_basepage_parsed', [$this, 'register_basepage_hooks']);
+
+    // Prevent AIOSEO from stomping on CiviCRM Shortcodes.
+    add_filter('aioseo_conflicting_shortcodes', [$this, 'aioseo_resolve_conflict']);
+
+  }
+
+  /**
+   * Register Base Page compatibility hooks.
+   *
+   * @since 5.66
+   */
+  public function register_basepage_hooks() {
+
+    // Add compatibility with Yoast SEO plugin's Open Graph title.
+    add_filter('wpseo_opengraph_title', [$this, 'wpseo_page_title'], 100, 1);
+
+    // Don't let the Yoast SEO plugin parse the Base Page title.
+    if (class_exists('WPSEO_Frontend')) {
+      $frontend = WPSEO_Frontend::get_instance();
+      remove_filter('pre_get_document_title', [$frontend, 'title'], 15);
+    }
+
+  }
+
+  /**
+   * Get CiviCRM Base Page title for Open Graph elements.
+   *
+   * Callback method for 'wpseo_opengraph_title' hook, to provide compatibility
+   * with the WordPress SEO plugin.
+   *
+   * @since 4.6.4
+   *
+   * @param string $post_title The title of the WordPress page or post.
+   * @return string $basepage_title The title of the CiviCRM entity.
+   */
+  public function wpseo_page_title($post_title) {
+
+    // Hand back our Base Page title.
+    return $this->civi->basepage->title_get();
+
+  }
+
+  /**
+   * Fixes AIOSEO's attempt to modify Shortcodes.
+   *
+   * @see https://civicrm.stackexchange.com/questions/40765/wp-all-in-one-seo-plugin-conflict
+   *
+   * @since 5.45
+   *
+   * @param array $conflicting_shortcodes The existing AIOSEO Conflicting Shortcodes array.
+   * @return array $conflicting_shortcodes The modified AIOSEO Conflicting Shortcodes array.
+   */
+  public function aioseo_resolve_conflict($conflicting_shortcodes) {
+    $conflicting_shortcodes['CiviCRM'] = 'civicrm';
+    return $conflicting_shortcodes;
+  }
+
+}

--- a/includes/compatibility/civicrm.polylang.php
+++ b/includes/compatibility/civicrm.polylang.php
@@ -1,0 +1,285 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+/**
+ * Polylang plugin compatatibility class.
+ *
+ * @since 5.66
+ */
+class CiviCRM_For_WordPress_Compat_Polylang {
+
+  /**
+   * @var object
+   * Plugin object reference.
+   * @since 5.66
+   * @access public
+   */
+  public $civi;
+
+  /**
+   * @var array
+   * Base Page data.
+   * @since 5.66
+   * @access private
+   */
+  private $basepages = [];
+
+  /**
+   * @var array
+   * Collected rewrites.
+   * @since 5.66
+   * @access private
+   */
+  private $rewrites = [];
+
+  /**
+   * Instance constructor.
+   *
+   * @since 5.66
+   */
+  public function __construct() {
+
+    // Store reference to CiviCRM plugin object.
+    $this->civi = civi_wp();
+
+    // Register plugin compatibility hooks.
+    $this->register_hooks();
+
+  }
+
+  /**
+   * Register hooks.
+   *
+   * This is called via the constructor during the "plugins_loaded" action which
+   * is much earlier that CiviCRM's own internal hooks. The reason for this is
+   * that compability may need callbacks for events that fire well before "init"
+   * which is when CiviCRM begins to load.
+   *
+   * @since 5.66
+   */
+  public function register_hooks() {
+
+    // Bail if CiviCRM not installed yet.
+    if (!CIVICRM_INSTALLED) {
+      return;
+    }
+
+    // Bail if Polylang is not present.
+    if (!function_exists('pll_languages_list')) {
+      return;
+    }
+
+    // Register Polylang compatibility callbacks.
+    add_action('civicrm_after_rewrite_rules', [$this, 'rewrite_rules'], 10, 2);
+    add_filter('pll_check_canonical_url', [$this, 'canonical_url'], 10, 2);
+    add_filter('civicrm/basepage/match', [$this, 'basepage_match'], 10, 2);
+    add_filter('civicrm/core/url/base', [$this, 'base_url_filter'], 10, 2);
+    add_filter('civicrm/core/locale', [$this, 'locale_filter'], 10, 2);
+
+  }
+
+  /**
+   * Support Polylang.
+   *
+   * @since 5.24
+   * @since 5.66 Moved to this class.
+   *
+   * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
+   * @param WP_Post $basepage The Base Page post object.
+   */
+  public function rewrite_rules($flush_rewrite_rules, $basepage) {
+
+    /*
+     * Collect all rewrite rules into an array.
+     *
+     * Because the array of specific Post IDs is added *after* the array of
+     * paths for the Base Page ID, those specific rewrite rules will "win" over
+     * the more general Base Page rules.
+     */
+    $collected_rewrites = [];
+
+    // Support prefixes for a single Base Page.
+    $basepage_url = get_permalink($basepage->ID);
+    $basepage_raw_url = PLL()->links_model->remove_language_from_link($basepage_url);
+    $language_slugs = pll_languages_list();
+    foreach ($language_slugs as $slug) {
+      $language = PLL()->model->get_language($slug);
+      $language_url = PLL()->links_model->add_language_to_link($basepage_raw_url, $language);
+      $parsed_url = wp_parse_url($language_url, PHP_URL_PATH);
+      $regex_path = substr($parsed_url, 1);
+      $collected_rewrites[$basepage->ID][] = $regex_path;
+      $post_id = pll_get_post($basepage->ID, $slug);
+      if (!empty($post_id)) {
+        $collected_rewrites[$post_id][] = $regex_path;
+      }
+    };
+
+    // Support prefixes for Base Pages in multiple languages.
+    foreach ($language_slugs as $slug) {
+      $post_id = pll_get_post($basepage->ID, $slug);
+      if (empty($post_id)) {
+        continue;
+      }
+      $url = get_permalink($post_id);
+      $parsed_url = wp_parse_url($url, PHP_URL_PATH);
+      $regex_path = substr($parsed_url, 1);
+      $collected_rewrites[$basepage->ID][] = $regex_path;
+      $collected_rewrites[$post_id][] = $regex_path;
+    };
+
+    // Make collection unique and add remaining rewrite rules.
+    $this->rewrites = array_map('array_unique', $collected_rewrites);
+    if (!empty($this->rewrites)) {
+      foreach ($this->rewrites as $post_id => $rewrite) {
+        foreach ($rewrite as $path) {
+          add_rewrite_rule(
+            '^' . $path . '([^?]*)?',
+            'index.php?page_id=' . $post_id . '&civiwp=CiviCRM&q=civicrm%2F$matches[1]',
+            'top'
+          );
+        }
+      }
+    }
+
+    // Maybe force flush.
+    if ($flush_rewrite_rules) {
+      flush_rewrite_rules();
+    }
+
+  }
+
+  /**
+   * Prevents Polylang from redirecting CiviCRM URLs.
+   *
+   * @since 5.66
+   *
+   * @param string|false $redirect_url False or the URL to redirect to.
+   * @param PLL_Language $language The language detected.
+   * @return string|false $redirect_url False or the URL to redirect to.
+   */
+  public function canonical_url($redirect_url, $language) {
+
+    // Bail if this is not a Page.
+    if (!is_page()) {
+      return $redirect_url;
+    }
+
+    // Bail if this is not a Base Page.
+    $post = get_post();
+    if (!empty($this->rewrites)) {
+      foreach ($this->rewrites as $post_id => $rewrite) {
+        if ($post_id === $post->ID) {
+          return FALSE;
+        }
+      }
+    }
+
+    return $redirect_url;
+
+  }
+
+  /**
+   * Checks Polylang for CiviCRM Base Page matches.
+   *
+   * @since 5.66
+   *
+   * @param bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+   * @param int $post_id The WordPress Post ID to check.
+   * @return bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+   */
+  public function basepage_match($is_basepage, $post_id) {
+
+    // Bail if this is already the Base Page.
+    if ($is_basepage) {
+      return $is_basepage;
+    }
+
+    // Bail if there are no rewrites.
+    if (empty($this->rewrites)) {
+      return $is_basepage;
+    }
+
+    foreach ($this->rewrites as $page_id => $rewrite) {
+      if ($post_id === $page_id) {
+        $is_basepage = TRUE;
+      }
+    }
+
+    return $is_basepage;
+
+  }
+
+  /**
+   * Filters the CiviCRM Base URL for the current language reported by Polylang.
+   *
+   * Only filters URLs that point to the front-end, since WordPress admin URLs are not
+   * rewritten by Polylang.
+   *
+   * @since 5.66
+   *
+   * @param str $url The URL as built by CiviCRM.
+   * @param bool $admin_request True if building an admin URL, false otherwise.
+   * @return str $url The URL as modified by Polylang.
+   */
+  public function base_url_filter($url, $admin_request) {
+
+    // Skip when not defined.
+    if (empty($url) || $admin_request) {
+      return $url;
+    }
+
+    // Find the language slug.
+    $slug = pll_current_language();
+    if (empty($slug)) {
+      return $url;
+    }
+
+    // Build the modified URL.
+    $raw_url = PLL()->links_model->remove_language_from_link($url);
+    $language = PLL()->model->get_language($slug);
+    $language_url = PLL()->links_model->add_language_to_link($raw_url, $language);
+
+    return $language_url;
+
+  }
+
+  /**
+   * Filters the CiviCRM locale for the current language as set by Polylang.
+   *
+   * @since 5.66
+   *
+   * @param str $locale The locale as reported by WordPress.
+   * @return str $locale The locale as modified by Polylang.
+   */
+  public function locale_filter($locale) {
+
+    $pll_locale = pll_current_language('locale');
+    if (!empty($pll_locale)) {
+      $locale = $pll_locale;
+    }
+
+    return $locale;
+
+  }
+
+}

--- a/includes/compatibility/civicrm.wpml.php
+++ b/includes/compatibility/civicrm.wpml.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+/**
+ * WPML plugin compatatibility class.
+ *
+ * @since 5.66
+ */
+class CiviCRM_For_WordPress_Compat_WPML {
+
+  /**
+   * @var object
+   * Plugin object reference.
+   * @since 5.66
+   * @access public
+   */
+  public $civi;
+
+  /**
+   * Instance constructor.
+   *
+   * @since 5.66
+   */
+  public function __construct() {
+
+    // Store reference to CiviCRM plugin object.
+    $this->civi = civi_wp();
+
+    // Register plugin compatibility hooks.
+    $this->register_hooks();
+
+  }
+
+  /**
+   * Register hooks.
+   *
+   * This is called via the constructor during the "plugins_loaded" action which
+   * is much earlier that CiviCRM's own internal hooks. The reason for this is
+   * that compability may need callbacks for events that fire well before "init"
+   * which is when CiviCRM begins to load.
+   *
+   * @since 5.66
+   */
+  public function register_hooks() {
+
+    // Bail if CiviCRM not installed yet.
+    if (!CIVICRM_INSTALLED) {
+      return;
+    }
+
+    // Bail if WPML is not present.
+    if (!defined('ICL_SITEPRESS_VERSION')) {
+      return;
+    }
+
+    // Register WPML compatibility callbacks.
+    add_filter('civicrm/core/locale', [$this, 'locale_filter'], 10, 2);
+
+  }
+
+  /**
+   * Filters the CiviCRM locale for the current language as set by WPML.
+   *
+   * @since 5.66
+   *
+   * @param str $locale The locale as reported by WordPress.
+   * @return str $locale The locale as modified by Polylang.
+   */
+  public function locale_filter($locale) {
+
+    $languages = apply_filters('wpml_active_languages', NULL);
+    foreach ($languages as $language) {
+      if ($language['active']) {
+        $locale = $language['default_locale'];
+        break;
+      }
+    }
+
+    return $locale;
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Solves [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/143). Hopefully provides a better framework for solving #289 as well.

Before
----------------------------------------
When Polylang is active, locale is lost on "secondary" or "internal" URLs built by CiviCRM Core. For example, on an Event Info screen (`https://example.org/fr/civicrm/event/info/?reset=1&id=3`) the "Register" link does not retain the current front-end locale but instead contains no locale information at all (`https://example.org/civicrm/event/register/?id=3&reset=1`). 

After
----------------------------------------
The link becomes `https://example.org/fr/civicrm/event/register/?id=3&reset=1` and retains the locale as defined by Polylang.

Technical Details
----------------------------------------
Requires a [corresponding PR on CiviCRM-Core](https://github.com/civicrm/civicrm-core/pull/27128).