### PR TITLE
Allow render shortcodes outside of the post_content

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -752,6 +752,16 @@ class CiviCRM_For_WordPress_Shortcodes {
    */
   private function get_for_post($content) {
 
+    /**
+     * Allows to include other shortcodes
+     * associated with the current post (e.g. a custom field).
+     *
+     * @since 5.64.3
+     *
+     * @param str the post content
+     */
+    $content = apply_filters('civicrm_content_shortcode', $content);
+
     // Init return array.
     $shortcodes = [];
 

--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -147,8 +147,18 @@ class CiviCRM_For_WordPress_Shortcodes {
 
         global $post;
 
+        /**
+         * Allows to check if there are other shortcodes
+         * associated with the current post (e.g. a custom field).
+         *
+         * @since 5.64.3
+         *
+         * @param bool the result of has_shortcode() function
+         */
+        $has_shortcode = apply_filters('civicrm_has_shortcode', has_shortcode($post->post_content, 'civicrm'));
+
         // Check for existence of Shortcode in content.
-        if (has_shortcode($post->post_content, 'civicrm')) {
+        if ($has_shortcode) {
 
           // Get CiviCRM Shortcodes in this post.
           $shortcodes_array = $this->get_for_post($post->post_content);


### PR DESCRIPTION
A practical situation: I had some shortcodes stored in the postmeta table and I need to render them in specific places on a page. Using the `civicrm_has_shortcode` filter, I can check if the post has any other shortcode. And with the `civicrm_content_shortcode` filter I can include these shortcodes in the list of shortcodes to be rendered.

It works better using `Remain in Shortcode Mode`.