### PR TITLE
[REF][PHP8.2] Declare properties

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -197,6 +197,34 @@ class CiviCRM_For_WordPress {
    */
   public $admin;
 
+  /**
+   * @var array
+   * Reference to the original $_GET value.
+   * @access protected
+   */
+  protected $wp_get;
+
+  /**
+   * @var array
+   * Reference to the original $_POST value.
+   * @access protected
+   */
+  protected $wp_post;
+
+  /**
+   * @var array
+   * Reference to the original $_COOKIE value.
+   * @access protected
+   */
+  protected $wp_cookie;
+
+  /**
+   * @var array
+   * Reference to the original $_REQUEST value.
+   * @access protected
+   */
+  protected $wp_request;
+
   // ---------------------------------------------------------------------------
   // Setup
   // ---------------------------------------------------------------------------

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -77,6 +77,13 @@ class CiviCRM_For_WordPress_Admin {
   public $metabox_quick_add;
 
   /**
+   * @var string
+   * Reference to the CiviCRM menu item's hook_suffix, in the WordPress admin menu.
+   * @access public
+   */
+  public $menu_page;
+
+  /**
    * Instance constructor.
    *
    * @since 5.33


### PR DESCRIPTION
Overview
----------------------------------------
Ensure properteies are declared, for PHP 8.2 compatiability.

Before
----------------------------------------
Dynamic properties are deprecated on PHP 8.2. CiviCRM-WordPress was using a handful of dynamic properties, causing deprecation notices.

After
----------------------------------------
Properties are declared.

Comments
----------------------------------------
I wasn't 100% sure whether to go `protected` or `public` for the `wp_get`, `wp_post`, `wp_cookie` and `wp_request` properties - happy to change them to public if that is deemed better.

I noticed most other properties in this repo have `@since` set in the docblocks, but I was not sure what was the appropriate value, so have not added the annotation to these new properties.