### PR TITLE
[NFC] Apply sub-set of WordPress codestyle

### DIFF
--- a/assets/templates/metaboxes/metabox.contact.add.php
+++ b/assets/templates/metaboxes/metabox.contact.add.php
@@ -17,6 +17,11 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.contact.add.php -->
 <?php
 
@@ -37,19 +42,19 @@ do_action('civicrm/metabox/contact/add/pre');
   <?php wp_nonce_field('civicrm_quick_add_action', 'civicrm_quick_add_nonce'); ?>
 
   <div class="input-text-wrap" id="contact-first-name-wrap">
-    <label for="civicrm_quick_add_first_name"><?php _e('First Name', 'civicrm'); ?></label>
+    <label for="civicrm_quick_add_first_name"><?php esc_html_e('First Name', 'civicrm'); ?></label>
     <input type="text" name="civicrm_quick_add_first_name" id="civicrm_quick_add_first_name" autocomplete="off" />
     <br class="clear" />
   </div>
 
   <div class="input-text-wrap" id="contact-last-name-wrap">
-    <label for="civicrm_quick_add_last_name"><?php _e('Last Name', 'civicrm'); ?></label>
+    <label for="civicrm_quick_add_last_name"><?php esc_html_e('Last Name', 'civicrm'); ?></label>
     <input type="text" name="civicrm_quick_add_last_name" id="civicrm_quick_add_last_name" autocomplete="off" />
     <br class="clear" />
   </div>
 
   <div class="input-text-wrap" id="contact-email-wrap">
-    <label for="civicrm_quick_add_email"><?php _e('Email', 'civicrm'); ?></label>
+    <label for="civicrm_quick_add_email"><?php esc_html_e('Email', 'civicrm'); ?></label>
     <input type="text" name="civicrm_quick_add_email" id="civicrm_quick_add_email" autocomplete="off" />
     <br class="clear" />
   </div>
@@ -63,7 +68,7 @@ do_action('civicrm/metabox/contact/add/pre');
 </form>
 
 <div class="contacts-added-wrap<?php echo $visiblity_class; ?>">
-  <h3><?php _e('Recently Added Contacts', 'civicrm'); ?></h3>
+  <h3><?php esc_html_e('Recently Added Contacts', 'civicrm'); ?></h3>
 
   <div class="civicrm_quick_add_success notice notice-success inline" style="background-color: #f7f7f7; display: none;">
     <p></p>

--- a/assets/templates/metaboxes/metabox.error.help.php
+++ b/assets/templates/metaboxes/metabox.error.help.php
@@ -17,8 +17,14 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.error.help.php -->
 <p><?php printf(
+  /* translators: 1: Opening anchor tag, 2: Closing anchor tag, 3: Opening anchor tag, 4: Closing anchor tag, 5: Opening anchor tag, 6: Closing anchor tag. */
   __('Please review the %1$sWordPress Installation Guide%2$s and the %3$sTroubleshooting page%4$s for assistance. If you still need help, you can often find solutions to your issue by searching for the error message in the %5$sinstallation support section of the community forum%6$s.', 'civicrm'),
   '<a href="https://docs.civicrm.org/installation/en/latest/wordpress/">', '</a>',
   '<a href="https://docs.civicrm.org/sysadmin/en/latest/troubleshooting/">', '</a>',

--- a/assets/templates/metaboxes/metabox.error.path.php
+++ b/assets/templates/metaboxes/metabox.error.path.php
@@ -17,14 +17,19 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.error.path.php -->
-<p><?php printf(
-  __('The path for including CiviCRM code files does appear to be set properly. Most likely there is an error in the %s setting in your CiviCRM settings file.', 'civicrm'),
-  '<code>civicrm_root</code>'
-); ?></p>
+<?php /* translators: %s: The HTML code tag wrapping a variable. */ ?>
+<p><?php printf(__('The path for including CiviCRM code files does appear to be set properly. Most likely there is an error in the %s setting in your CiviCRM settings file.', 'civicrm'), '<code>civicrm_root</code>'); ?></p>
 
-<p><?php _e('Your CiviCRM settings file location is set to:', 'civicrm'); ?><br><pre><?php echo CIVICRM_SETTINGS_PATH; ?></pre></p>
+<p><?php esc_html_e('Your CiviCRM settings file location is set to:', 'civicrm'); ?><br><pre><?php echo esc_html(CIVICRM_SETTINGS_PATH); ?></pre></p>
 
+<?php /* translators: %s: The HTML code tag wrapping a variable. */ ?>
 <p><?php printf(__('%s is currently set to:', 'civicrm'), '<code>civicrm_root</code>'); ?><br><pre><?php echo $civicrm_root; ?></pre></p>
 
+<?php /* translators: %s: The HTML code tag wrapping a variable. */ ?>
 <p><?php printf(__('Please check that your CiviCRM settings file is where it should be and that %s is set correctly in it. Also check that the CiviCRM code directory is where it should be. If these are both fine, then you will have to look in your logs for more information.', 'civicrm'), '<code>civicrm_root</code>'); ?></p>

--- a/assets/templates/metaboxes/metabox.error.php.php
+++ b/assets/templates/metaboxes/metabox.error.php.php
@@ -17,13 +17,15 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.error.php.php -->
-<p><?php printf(
-  __('CiviCRM requires PHP version %1$s or greater. You are running PHP version %2$s', 'civicrm'),
-  CIVICRM_WP_PHP_MINIMUM,
-  PHP_VERSION
-); ?></p>
+<?php /* translators: 1: The minimum PHP version, 2: The current PHP version. */ ?>
+<p><?php printf(__('CiviCRM requires PHP version %1$s or greater. You are running PHP version %2$s', 'civicrm'), CIVICRM_WP_PHP_MINIMUM, PHP_VERSION); ?></p>
 
-<p><?php _e('You will have to upgrade PHP before you can run this version CiviCRM.', 'civicrm'); ?></p>
+<p><?php esc_html_e('You will have to upgrade PHP before you can run this version CiviCRM.', 'civicrm'); ?></p>
 
-<p><?php _e('To continue using CiviCRM without upgrading PHP, you will have to revert both the plugin and the database to a backup of your previous version.', 'civicrm'); ?></p>
+<p><?php esc_html_e('To continue using CiviCRM without upgrading PHP, you will have to revert both the plugin and the database to a backup of your previous version.', 'civicrm'); ?></p>

--- a/assets/templates/metaboxes/metabox.options.basepage.php
+++ b/assets/templates/metaboxes/metabox.options.basepage.php
@@ -17,6 +17,11 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.options.basepage.php -->
 <?php
 
@@ -33,15 +38,15 @@ do_action('civicrm/metabox/basepage/pre');
 </div>
 
 <p>
-  <?php _e('CiviCRM needs a WordPress Page to show its content on the public-facing pages of your website.', 'civicrm'); ?>
+  <?php esc_html_e('CiviCRM needs a WordPress Page to show its content on the public-facing pages of your website.', 'civicrm'); ?>
   <?php if (!($basepage instanceof WP_Post)) : ?>
-    <em class="basepage_feedback"><?php _e('Please select a Page from the drop-down for CiviCRM to use as its Base Page. If CiviCRM was able to create one automatically, there should be one with the title "CiviCRM". If not, please select another suitable WordPress Page.', 'civicrm'); ?></em>
+    <em class="basepage_feedback"><?php esc_html_e('Please select a Page from the drop-down for CiviCRM to use as its Base Page. If CiviCRM was able to create one automatically, there should be one with the title "CiviCRM". If not, please select another suitable WordPress Page.', 'civicrm'); ?></em>
   <?php else : ?>
-    <em class="basepage_feedback"><?php _e('It appears that your Base Page has been set. Looking good.', 'civicrm'); ?></em>
+    <em class="basepage_feedback"><?php esc_html_e('It appears that your Base Page has been set. Looking good.', 'civicrm'); ?></em>
   <?php endif; ?>
 </p>
 
-<label for="page_id" class="screen-reader-text"><?php _e('Choose Base Page', 'civicrm'); ?></label>
+<label for="page_id" class="screen-reader-text"><?php esc_html_e('Choose Base Page', 'civicrm'); ?></label>
 <?php wp_dropdown_pages($params); ?>
 
 <p class="submit">

--- a/assets/templates/metaboxes/metabox.options.cache.php
+++ b/assets/templates/metaboxes/metabox.options.cache.php
@@ -17,6 +17,11 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.options.cache.php -->
 <?php
 
@@ -35,7 +40,7 @@ do_action('civicrm/metabox/cache/pre');
   <p></p>
 </div>
 
-<p><?php _e('You may sometimes find yourself in situations that require the CiviCRM caches to be cleared, e.g. when template files need to be refreshed.', 'civicrm'); ?></p>
+<p><?php esc_html_e('You may sometimes find yourself in situations that require the CiviCRM caches to be cleared, e.g. when template files need to be refreshed.', 'civicrm'); ?></p>
 
 <p class="submit">
   <?php submit_button(esc_html__('Clear Caches', 'civicrm'), 'primary', 'civicrm_cache_submit', FALSE, $options); ?>

--- a/assets/templates/metaboxes/metabox.options.email.php
+++ b/assets/templates/metaboxes/metabox.options.email.php
@@ -17,6 +17,11 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.options.email.php -->
 <?php
 
@@ -32,9 +37,9 @@ do_action('civicrm/metabox/email_sync/pre');
   <p></p>
 </div>
 
-<p><?php _e('When a WordPress User updates their Email, CiviCRM will automatically update the Primary Email of their linked Contact record. This setting lets you choose whether the reverse update should happen - i.e. if the Primary Email of a Contact that has a linked WordPress User is updated, do you want CiviCRM to update the WordPress User Email?', 'civicrm'); ?></p>
+<p><?php esc_html_e('When a WordPress User updates their Email, CiviCRM will automatically update the Primary Email of their linked Contact record. This setting lets you choose whether the reverse update should happen - i.e. if the Primary Email of a Contact that has a linked WordPress User is updated, do you want CiviCRM to update the WordPress User Email?', 'civicrm'); ?></p>
 
-<label for="sync_email" class="screen-reader-text"><?php _e('Sync Emails', 'civicrm'); ?></label>
+<label for="sync_email" class="screen-reader-text"><?php esc_html_e('Sync Emails', 'civicrm'); ?></label>
 <select name="sync_email" id="sync_email">
   <option value="yes"<?php echo $selected_yes; ?>><?php esc_html_e('Yes', 'civicrm'); ?></option>
   <option value="no"<?php echo $selected_no; ?>><?php esc_html_e('No', 'civicrm'); ?></option>

--- a/assets/templates/metaboxes/metabox.options.links.php
+++ b/assets/templates/metaboxes/metabox.options.links.php
@@ -17,6 +17,11 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.options.links.php -->
 <?php
 
@@ -28,7 +33,7 @@
 do_action('civicrm/metabox/links/pre');
 
 ?>
-<p><?php _e('Below is a list of shortcuts to some CiviCRM admin pages that are important when you are setting up CiviCRM. When these settings are correctly configured, your CiviCRM installation should be ready for you to customise to your requirements.', 'civicrm'); ?></p>
+<p><?php esc_html_e('Below is a list of shortcuts to some CiviCRM admin pages that are important when you are setting up CiviCRM. When these settings are correctly configured, your CiviCRM installation should be ready for you to customise to your requirements.', 'civicrm'); ?></p>
 
 <ul>
   <?php foreach ($admin_links as $admin_link) : ?>
@@ -40,7 +45,7 @@ do_action('civicrm/metabox/links/pre');
 
 <hr>
 
-<p><?php _e('Shortcuts to some CiviCRM maintenance tasks.', 'civicrm'); ?></p>
+<p><?php esc_html_e('Shortcuts to some CiviCRM maintenance tasks.', 'civicrm'); ?></p>
 
 <ul>
   <?php foreach ($maintenance_links as $maintenance_link) : ?>

--- a/assets/templates/metaboxes/metabox.options.permissions.php
+++ b/assets/templates/metaboxes/metabox.options.permissions.php
@@ -17,6 +17,11 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.options.permissions.php -->
 <?php
 

--- a/assets/templates/metaboxes/metabox.options.shortcode.php
+++ b/assets/templates/metaboxes/metabox.options.shortcode.php
@@ -17,6 +17,11 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.options.shortcode.php -->
 <?php
 
@@ -32,9 +37,9 @@ do_action('civicrm/metabox/shortcode/pre');
   <p></p>
 </div>
 
-<p><?php _e('When a CiviCRM Shortcode is embedded in a Post/Page without "hijack" being set, it is shown embedded in the content in "Shortcode Mode". If any action is taken via the Shortcode, a query string is appended to the URL and the Post/Page is shown in "Base Page Mode" and the title and content are overwritten. Choose to keep this legacy behaviour or move to the new "Remain in Shortcode Mode" behaviour.', 'civicrm'); ?></p>
+<p><?php esc_html_e('When a CiviCRM Shortcode is embedded in a Post/Page without "hijack" being set, it is shown embedded in the content in "Shortcode Mode". If any action is taken via the Shortcode, a query string is appended to the URL and the Post/Page is shown in "Base Page Mode" and the title and content are overwritten. Choose to keep this legacy behaviour or move to the new "Remain in Shortcode Mode" behaviour.', 'civicrm'); ?></p>
 
-<label for="shortcode_mode" class="screen-reader-text"><?php _e('Display Mode', 'civicrm'); ?></label>
+<label for="shortcode_mode" class="screen-reader-text"><?php esc_html_e('Display Mode', 'civicrm'); ?></label>
 <select name="shortcode_mode" id="shortcode_mode">
   <option value="modern"<?php echo $selected_modern; ?>><?php esc_html_e('Remain in Shortcode Mode', 'civicrm'); ?></option>
   <option value="legacy"<?php echo $selected_legacy; ?>><?php esc_html_e('Legacy Base Page Mode', 'civicrm'); ?></option>

--- a/assets/templates/metaboxes/metabox.repo.ext.php
+++ b/assets/templates/metaboxes/metabox.repo.ext.php
@@ -17,19 +17,24 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.repo.ext.php -->
-<p><?php _e('Extensions are a bit like plugins because they enhance what CiviCRM can do. You can find, install and manage many of them in CiviCRM.', 'civicrm'); ?></p>
+<p><?php esc_html_e('Extensions are a bit like plugins because they enhance what CiviCRM can do. You can find, install and manage many of them in CiviCRM.', 'civicrm'); ?></p>
 
 <ul>
-  <li><em><a href="<?php echo $extensions_url; ?>"><?php _e('Go to your CiviCRM Extensions Page', 'civicrm'); ?></a></em></li>
+  <li><em><a href="<?php echo $extensions_url; ?>"><?php esc_html_e('Go to your CiviCRM Extensions Page', 'civicrm'); ?></a></em></li>
 </ul>
 
 <hr/>
 
-<p><?php _e('Here are some other places you can find them.', 'civicrm'); ?></p>
+<p><?php esc_html_e('Here are some other places you can find them.', 'civicrm'); ?></p>
 
 <ul>
-  <li><em><a href="https://civicrm.org/extensions/wordpress"><?php _e('Search CiviCRM Website for "Extensions" that are compatible with WordPress', 'civicrm'); ?></a></em></li>
-  <li><em><a href="https://lab.civicrm.org/explore/projects?tag=wordpress"><?php _e('Search CiviCRM GitLab for "Extensions" that are compatible with WordPress', 'civicrm'); ?></a></em></li>
-  <li><em><a href="https://github.com/search?p=2&q=civicrm+extension&type=Repositories"><?php _e('Search GitHub for "CiviCRM Extensions"', 'civicrm'); ?></a></em></li>
+  <li><em><a href="https://civicrm.org/extensions/wordpress"><?php esc_html_e('Search CiviCRM Website for "Extensions" that are compatible with WordPress', 'civicrm'); ?></a></em></li>
+  <li><em><a href="https://lab.civicrm.org/explore/projects?tag=wordpress"><?php esc_html_e('Search CiviCRM GitLab for "Extensions" that are compatible with WordPress', 'civicrm'); ?></a></em></li>
+  <li><em><a href="https://github.com/search?p=2&q=civicrm+extension&type=Repositories"><?php esc_html_e('Search GitHub for "CiviCRM Extensions"', 'civicrm'); ?></a></em></li>
 </ul>

--- a/assets/templates/metaboxes/metabox.repo.git.php
+++ b/assets/templates/metaboxes/metabox.repo.git.php
@@ -17,13 +17,18 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.repo.git.php -->
-<p><?php _e('For the more adventurous, here is a list of plugins that are hosted in git repositories around the web. You may need a bit more technical confidence to install and upgrade these plugins.', 'civicrm'); ?></p>
+<p><?php esc_html_e('For the more adventurous, here is a list of plugins that are hosted in git repositories around the web. You may need a bit more technical confidence to install and upgrade these plugins.', 'civicrm'); ?></p>
 
 <hr/>
 
 <ul>
-  <li><em><a href="https://github.com/search?q=civicrm+wordpress&amp;type=Repositories"><?php _e('Search GitHub for CiviCRM &amp; WordPress', 'civicrm'); ?></a></em></li>
+  <li><em><a href="https://github.com/search?q=civicrm+wordpress&amp;type=Repositories"><?php esc_html_e('Search GitHub for CiviCRM &amp; WordPress', 'civicrm'); ?></a></em></li>
 </ul>
 
 <hr/>
@@ -31,16 +36,16 @@
 <div class="plugin-repo-list-wrapper">
   <?php if (!empty($plugins->messages)) : ?>
     <ul class="plugin-repo-list">
-      <?php foreach ($plugins->messages as $plugin) : ?>
+      <?php foreach ($plugins->messages as $civicrm_plugin) : ?>
         <li>
-          <strong><a href="<?php echo $plugin['url']; ?>/"><?php echo $plugin['name']; ?></a></strong><br>
-          <?php if (!empty($plugin['short_description'])) : ?>
-            <span class="description"><?php echo $plugin['short_description']; ?></span><br>
+          <strong><a href="<?php echo esc_url($civicrm_plugin['url']); ?>/"><?php echo esc_html($civicrm_plugin['name']); ?></a></strong><br>
+          <?php if (!empty($civicrm_plugin['short_description'])) : ?>
+            <span class="description"><?php echo esc_html($civicrm_plugin['short_description']); ?></span><br>
           <?php endif; ?>
         </li>
       <?php endforeach; ?>
     </ul>
   <?php else : ?>
-    <p><?php _e('Could not fetch list of plugins.', 'civicrm'); ?></p>
+    <p><?php esc_html_e('Could not fetch list of plugins.', 'civicrm'); ?></p>
   <?php endif; ?>
 </div>

--- a/assets/templates/metaboxes/metabox.repo.wordpress.php
+++ b/assets/templates/metaboxes/metabox.repo.wordpress.php
@@ -17,14 +17,19 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/metaboxes/metabox.repo.wordpress.php -->
-<p><?php _e('The easiest way to extend CiviCRM and integrate it with WordPress is through installing plugins that are hosted in the WordPress Plugin Directory. These can be installed and updated through the normal WordPress admin screens.', 'civicrm'); ?></p>
+<p><?php esc_html_e('The easiest way to extend CiviCRM and integrate it with WordPress is through installing plugins that are hosted in the WordPress Plugin Directory. These can be installed and updated through the normal WordPress admin screens.', 'civicrm'); ?></p>
 
 <hr/>
 
 <ul>
-  <li><em><a href="https://wordpress.org/plugins/tags/civicrm/"><?php _e('Search the WordPress Plugin Directory for plugins tagged CiviCRM', 'civicrm'); ?></a></em></li>
-  <li><em><a href="https://wordpress.org/plugins/search/civicrm/"><?php _e('Search the WordPress Plugin Directory for references to CiviCRM', 'civicrm'); ?></a></em></li>
+  <li><em><a href="https://wordpress.org/plugins/tags/civicrm/"><?php esc_html_e('Search the WordPress Plugin Directory for plugins tagged CiviCRM', 'civicrm'); ?></a></em></li>
+  <li><em><a href="https://wordpress.org/plugins/search/civicrm/"><?php esc_html_e('Search the WordPress Plugin Directory for references to CiviCRM', 'civicrm'); ?></a></em></li>
 </ul>
 
 <hr/>
@@ -32,20 +37,26 @@
 <div class="plugin-directory-list-wrapper">
   <?php if (!empty($plugins->plugins)) : ?>
     <ul class="plugin-directory-list">
-      <?php foreach ($plugins->plugins as $plugin) : ?>
+      <?php foreach ($plugins->plugins as $civicrm_plugin) : ?>
         <li>
-          <strong><a href="<?php echo __('https://wordpress.org/plugins/') . $plugin['slug']; ?>/"><?php echo $plugin['name']; ?></a></strong><br>
-          <?php printf(__('Version %s', 'civicrm'), $plugin['version']); ?><br>
-          <?php printf(__('%d+ active installations', 'civicrm'), $plugin['active_installs']); ?></br>
-          <?php printf(__('Tested up to WordPress %s', 'civicrm'), $plugin['tested']); ?><br>
-          <?php printf(__('Last updated %s ago', 'civicrm'), human_time_diff(strtotime($plugin['last_updated']))); ?><br>
-          <?php if (!empty($plugin['short_description'])) : ?>
-            <span class="description"><?php echo $plugin['short_description']; ?></span><br>
+          <?php /* Deliberate use of default domain so that WordPress "translates" the URL. */ ?>
+          <?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?>
+          <strong><a href="<?php echo esc_url(__('https://wordpress.org/plugins/') . $civicrm_plugin['slug']); ?>/"><?php echo esc_html($civicrm_plugin['name']); ?></a></strong><br>
+          <?php /* translators: %s: The plugin version. */ ?>
+          <?php echo esc_html(sprintf(__('Version %s', 'civicrm'), $civicrm_plugin['version'])); ?><br>
+          <?php /* translators: %d: The number of installs. */ ?>
+          <?php echo esc_html(sprintf(__('%d+ active installations', 'civicrm'), $civicrm_plugin['active_installs'])); ?></br>
+          <?php /* translators: %s: The version of WordPress the plugin is tested to. */ ?>
+          <?php echo esc_html(sprintf(__('Tested up to WordPress %s', 'civicrm'), $civicrm_plugin['tested'])); ?><br>
+          <?php /* translators: %s: The date of the last plugin update. */ ?>
+          <?php echo esc_html(sprintf(__('Last updated %s ago', 'civicrm'), human_time_diff(strtotime($civicrm_plugin['last_updated'])))); ?><br>
+          <?php if (!empty($civicrm_plugin['short_description'])) : ?>
+            <span class="description"><?php echo esc_html($civicrm_plugin['short_description']); ?></span><br>
           <?php endif; ?>
         </li>
       <?php endforeach; ?>
     </ul>
   <?php else : ?>
-    <p><?php _e('Could not fetch list of plugins.', 'civicrm'); ?></p>
+    <p><?php esc_html_e('Could not fetch list of plugins.', 'civicrm'); ?></p>
   <?php endif; ?>
 </div>

--- a/assets/templates/pages/page.error.php
+++ b/assets/templates/pages/page.error.php
@@ -17,14 +17,19 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/page.error.php -->
 <div class="wrap civicrm-wrap civicrm-error-wrap">
 
   <img src="<?php echo CIVICRM_PLUGIN_URL . 'assets/images/civicrm-logo.png'; ?>" width="160" height="42" alt="<?php esc_attr_e('CiviCRM Logo', 'civicrm'); ?>" id="civicrm-logo">
 
-  <h1><?php _e('CiviCRM Troubleshooting', 'civicrm'); ?></h1>
+  <h1><?php esc_html_e('CiviCRM Troubleshooting', 'civicrm'); ?></h1>
 
-  <p><?php _e('Something seems to be wrong with your CiviCRM installation. This page will help you try and troubleshoot the problem.', 'civicrm'); ?></p>
+  <p><?php esc_html_e('Something seems to be wrong with your CiviCRM installation. This page will help you try and troubleshoot the problem.', 'civicrm'); ?></p>
 
   <form method="post" id="civicrm_error_form" action="">
 
@@ -34,14 +39,14 @@
 
     <div id="poststuff">
 
-      <div id="post-body" class="metabox-holder columns-<?php echo $columns;?>">
+      <div id="post-body" class="metabox-holder columns-<?php echo $columns; ?>">
 
         <div id="postbox-container-1" class="postbox-container">
           <?php do_meta_boxes($screen->id, 'side', NULL); ?>
         </div>
 
         <div id="postbox-container-2" class="postbox-container">
-          <?php do_meta_boxes($screen->id, 'normal', NULL);  ?>
+          <?php do_meta_boxes($screen->id, 'normal', NULL); ?>
           <?php do_meta_boxes($screen->id, 'advanced', NULL); ?>
         </div>
 

--- a/assets/templates/pages/page.integration.php
+++ b/assets/templates/pages/page.integration.php
@@ -17,14 +17,19 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/page.integration.php -->
 <div class="wrap civicrm-wrap civicrm-integration-wrap">
 
   <img src="<?php echo CIVICRM_PLUGIN_URL . 'assets/images/civicrm-logo.png'; ?>" width="160" height="42" alt="<?php esc_attr_e('CiviCRM Logo', 'civicrm'); ?>" id="civicrm-logo">
 
-  <h1><?php _e('Integrating CiviCRM with WordPress', 'civicrm'); ?></h1>
+  <h1><?php esc_html_e('Integrating CiviCRM with WordPress', 'civicrm'); ?></h1>
 
-  <p><?php _e('We have collected some resources to help you make the most of CiviCRM in WordPress.', 'civicrm'); ?></p>
+  <p><?php esc_html_e('We have collected some resources to help you make the most of CiviCRM in WordPress.', 'civicrm'); ?></p>
 
   <form method="post" id="civicrm_integration_form" action="<?php /* echo $this->page_submit_url_get(); */ ?>">
 
@@ -39,7 +44,7 @@
       <div id="dashboard-widgets" class="metabox-holder<?php echo $columns_css; ?>">
 
         <div id="postbox-container-1" class="postbox-container">
-          <?php do_meta_boxes($screen->id, 'normal', '');  ?>
+          <?php do_meta_boxes($screen->id, 'normal', ''); ?>
         </div>
 
         <div id="postbox-container-2" class="postbox-container">

--- a/assets/templates/pages/page.options.php
+++ b/assets/templates/pages/page.options.php
@@ -17,14 +17,19 @@
  *
  */
 
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
 ?><!-- assets/templates/page.options.php -->
 <div class="wrap civicrm-wrap civicrm-settings-wrap">
 
   <img src="<?php echo CIVICRM_PLUGIN_URL . 'assets/images/civicrm-logo.png'; ?>" width="160" height="42" alt="<?php esc_attr_e('CiviCRM Logo', 'civicrm'); ?>" id="civicrm-logo">
 
-  <h1><?php _e('CiviCRM Settings', 'civicrm'); ?></h1>
+  <h1><?php esc_html_e('CiviCRM Settings', 'civicrm'); ?></h1>
 
-  <p><?php _e('We have collected some settings here because they are important for configuring CiviCRM in WordPress.', 'civicrm'); ?></p>
+  <p><?php esc_html_e('We have collected some settings here because they are important for configuring CiviCRM in WordPress.', 'civicrm'); ?></p>
 
   <form method="post" id="civicrm_options_form" action="<?php echo $this->page_submit_url_get(); ?>">
 
@@ -40,7 +45,7 @@
       <div id="dashboard-widgets" class="metabox-holder<?php echo $columns_css; ?>">
 
         <div id="postbox-container-1" class="postbox-container">
-          <?php do_meta_boxes($screen->id, 'normal', '');  ?>
+          <?php do_meta_boxes($screen->id, 'normal', ''); ?>
         </div>
 
         <div id="postbox-container-2" class="postbox-container">

--- a/includes/admin-pages/civicrm.page.error.php
+++ b/includes/admin-pages/civicrm.page.error.php
@@ -180,7 +180,7 @@ class CiviCRM_For_WordPress_Admin_Page_Error {
     do_action('civicrm/page/error/add_meta_boxes', $screen->id);
 
     // Grab columns.
-    $columns = (1 == $screen->get_columns() ? '1' : '2');
+    $columns = (1 === $screen->get_columns() ? '1' : '2');
 
     // Include template file.
     include CIVICRM_PLUGIN_DIR . 'assets/templates/pages/page.error.php';

--- a/includes/admin-pages/civicrm.page.integration.php
+++ b/includes/admin-pages/civicrm.page.integration.php
@@ -306,7 +306,7 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
     // Query again if it's not found.
     if ($plugins === FALSE) {
 
-      // Build query
+      // Build query.
       $query = [
         'tag' => 'civicrm',
         'fields' => [
@@ -374,7 +374,7 @@ class CiviCRM_For_WordPress_Admin_Page_Integration {
           // We're good - grab the actual data.
           $plugins = json_decode(wp_remote_retrieve_body($response), TRUE);
 
-          // Store for a week given how infrequently plugins are added,
+          // Store for a week given how infrequently plugins are added.
           set_site_transient('civicrm_plugins_by_repo', $plugins, 1 * WEEK_IN_SECONDS);
 
         }

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -165,7 +165,8 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
       'civicrm-options-script',
       CIVICRM_PLUGIN_URL . 'assets/js/civicrm.options.js',
       ['jquery'],
-      CIVICRM_PLUGIN_VERSION
+      CIVICRM_PLUGIN_VERSION,
+      FALSE
     );
 
     // Init settings and localisation array.
@@ -425,7 +426,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     $params = [
       'post_type' => 'page',
       'sort_column' => 'menu_order, post_title',
-      'show_option_none' => __('- Select a Base Page -'),
+      'show_option_none' => __('- Select a Base Page -', 'civicrm'),
     ];
 
     // If the Base Page is set, add its ID.
@@ -696,6 +697,10 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
    */
   public function form_submitted() {
 
+    // Nonce is irrelevant at this stage.
+    // phpcs:disable WordPress.Security.NonceVerification.Recommended
+    // phpcs:disable WordPress.Security.NonceVerification.Missing
+
     if (!empty($_POST['civicrm_basepage_post_submit'])) {
       // Save Base Page.
       $this->form_nonce_check();
@@ -727,6 +732,9 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
       $this->form_redirect();
     }
 
+    // phpcs:enable WordPress.Security.NonceVerification.Recommended
+    // phpcs:enable WordPress.Security.NonceVerification.Missing
+
   }
 
   /**
@@ -734,10 +742,13 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
    *
    * @since 5.34
    */
-  public function form_save_basepage() {
+  private function form_save_basepage() {
 
     // Bail if there's no valid Post ID.
-    $post_id = empty($_POST['page_id']) ? 0 : (int) trim($_POST['page_id']);
+    // Nonce is checked in self::form_nonce_check().
+    // phpcs:disable WordPress.Security.NonceVerification.Missing
+    $post_id = empty($_POST['page_id']) ? 0 : (int) sanitize_text_field(wp_unslash($_POST['page_id']));
+    // phpcs:enable WordPress.Security.NonceVerification.Missing
     if ($post_id === 0) {
       return;
     }
@@ -760,10 +771,13 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
    *
    * @since 5.44
    */
-  public function form_save_shortcode() {
+  private function form_save_shortcode() {
 
     // Bail if there is no valid chosen value.
-    $chosen = isset($_POST['shortcode_mode']) ? trim($_POST['shortcode_mode']) : 0;
+    // Nonce is checked in self::form_nonce_check().
+    // phpcs:disable WordPress.Security.NonceVerification.Missing
+    $chosen = isset($_POST['shortcode_mode']) ? sanitize_text_field(wp_unslash($_POST['shortcode_mode'])) : 0;
+    // phpcs:enable WordPress.Security.NonceVerification.Missing
     if ($chosen === 0 || !in_array($chosen, $this->civi->admin->get_shortcode_modes())) {
       return;
     }
@@ -778,10 +792,13 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
    *
    * @since 5.34
    */
-  public function form_save_email_sync() {
+  private function form_save_email_sync() {
 
     // Bail if there is no valid chosen value.
-    $chosen = isset($_POST['sync_email']) ? trim($_POST['sync_email']) : 0;
+    // Nonce is checked in self::form_nonce_check().
+    // phpcs:disable WordPress.Security.NonceVerification.Missing
+    $chosen = isset($_POST['sync_email']) ? sanitize_text_field(wp_unslash($_POST['sync_email'])) : 0;
+    // phpcs:enable WordPress.Security.NonceVerification.Missing
     if ($chosen === 0) {
       return;
     }
@@ -854,7 +871,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     }
 
     // Bail if there's no valid Post ID.
-    $post_id = empty($_POST['value']) ? 0 : (int) trim($_POST['value']);
+    $post_id = empty($_POST['value']) ? 0 : (int) sanitize_text_field(wp_unslash($_POST['value']));
     if ($post_id === 0) {
       $data['notice'] = __('No Page ID detected. Unable to save the WordPress Base Page.', 'civicrm');
       wp_send_json($data);
@@ -931,7 +948,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     }
 
     // Bail if there is no valid chosen value.
-    $chosen = isset($_POST['value']) ? trim($_POST['value']) : 0;
+    $chosen = isset($_POST['value']) ? sanitize_text_field(wp_unslash($_POST['value'])) : 0;
     if ($chosen === 0 || !in_array($chosen, $this->civi->admin->get_shortcode_modes())) {
       $data['notice'] = __('Unrecognised parameter. Could not save the selected setting.', 'civicrm');
       wp_send_json($data);
@@ -975,7 +992,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     }
 
     // Bail if there is no valid chosen value.
-    $chosen = isset($_POST['value']) ? trim($_POST['value']) : 0;
+    $chosen = isset($_POST['value']) ? sanitize_text_field(wp_unslash($_POST['value'])) : 0;
     if ($chosen === 0) {
       $data['notice'] = __('Unrecognised parameter. Could not save the selected setting.', 'civicrm');
       wp_send_json($data);
@@ -1031,7 +1048,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     }
 
     // Bail if there is no valid chosen value.
-    $chosen = isset($_POST['value']) ? trim($_POST['value']) : 0;
+    $chosen = isset($_POST['value']) ? sanitize_text_field(wp_unslash($_POST['value'])) : 0;
     if ($chosen === 0 || !in_array($chosen, ['enable', 'disable'])) {
       $data['notice'] = __('Unrecognised parameter. Could not refresh the CiviCRM permissions.', 'civicrm');
       wp_send_json($data);
@@ -1092,8 +1109,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     }
 
     // Bail if there is no valid value.
-    $chosen = isset($_POST['value']) ? (int) trim($_POST['value']) : 0;
-
+    $chosen = isset($_POST['value']) ? (int) sanitize_text_field(wp_unslash($_POST['value'])) : 0;
     if ($chosen !== 1) {
       $data['notice'] = __('Unrecognised parameter. Could not clear the CiviCRM caches.', 'civicrm');
       wp_send_json($data);

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -208,11 +208,12 @@ class CiviCRM_For_WordPress_Admin {
     }
 
     // Bail if we are on our installer page.
-    if ($screen->id == 'toplevel_page_civicrm-install') {
+    if ($screen->id === 'toplevel_page_civicrm-install') {
       return;
     }
 
     $message = sprintf(
+      /* translators: 1: Opening strong tag, 2: Closing strong tag, 3: Opening anchor tag, 4: Closing anchor tag. */
       __('%1$sCiviCRM is almost ready.%2$s You must %3$sconfigure CiviCRM%4$s for it to work.', 'civicrm'),
       '<strong>',
       '</strong>',
@@ -234,6 +235,7 @@ class CiviCRM_For_WordPress_Admin {
   public function run_installer() {
 
     // Set install type.
+    // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
     $_GET['civicrm_install_type'] = 'wordpress';
 
     $civicrmCore = CIVICRM_PLUGIN_DIR . 'civicrm';
@@ -300,11 +302,12 @@ class CiviCRM_For_WordPress_Admin {
     }
 
     // Bail if we are on our error page.
-    if ($screen->id == 'toplevel_page_CiviCRM') {
+    if ($screen->id === 'toplevel_page_CiviCRM') {
       return;
     }
 
     $message = sprintf(
+      /* translators: 1: Opening strong tag, 2: Closing strong tag, 3: Opening anchor tag, 4: Closing anchor tag. */
       __('%1$sCiviCRM needs your attention.%2$s Please visit the %3$sInformation Page%4$s for details.', 'civicrm'),
       '<strong>',
       '</strong>',
@@ -407,7 +410,7 @@ class CiviCRM_For_WordPress_Admin {
      * including "civicrm.settings.php" will throw a fatal error if $civicrm_root
      * is wrong.
      */
-    if ($error == FALSE) {
+    if ($error === FALSE) {
       $this->error_flag = 'settings-include';
       $initialized = FALSE;
       return FALSE;
@@ -431,7 +434,7 @@ class CiviCRM_For_WordPress_Admin {
     $error = include_once 'CRM/Core/Config.php';
 
     // Bail if the config file returns something other than int(1).
-    if ($error == FALSE) {
+    if ($error === FALSE) {
       $this->error_flag = 'config-include';
       $initialized = FALSE;
       return FALSE;
@@ -512,7 +515,7 @@ class CiviCRM_For_WordPress_Admin {
     }
 
     // Bail if this is not CiviCRM admin.
-    if ($pagenow != 'admin.php' || FALSE === strpos($current_screen['query'], 'page=CiviCRM')) {
+    if ($pagenow !== 'admin.php' || FALSE === strpos($current_screen['query'], 'page=CiviCRM')) {
       return $settings;
     }
 
@@ -544,7 +547,7 @@ class CiviCRM_For_WordPress_Admin {
 
     // Delete the option if conditions are met.
     if ($dao instanceof CRM_Core_DAO_Setting) {
-      if (isset($dao->name) && $dao->name == 'wpBasePage') {
+      if (isset($dao->name) && $dao->name === 'wpBasePage') {
         delete_option('civicrm_rules_flushed');
       }
     }
@@ -558,6 +561,11 @@ class CiviCRM_For_WordPress_Admin {
    *
    * @since 5.28
    * @since 5.33 Moved to this class.
+   *
+   * @param string $html The auto-update markup.
+   * @param string $plugin_file The path to the plugin.
+   * @param array $plugin_data An array of plugin data.
+   * @return string $html The modified auto-update markup.
    */
   public function auto_update_prevent($html, $plugin_file, $plugin_data) {
 
@@ -602,6 +610,7 @@ class CiviCRM_For_WordPress_Admin {
    */
   public function add_menu_items() {
 
+    // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
     $civilogo = file_get_contents(CIVICRM_PLUGIN_DIR . 'assets/images/civilogo.svg.b64');
 
     global $wp_version;
@@ -713,7 +722,7 @@ class CiviCRM_For_WordPress_Admin {
 
     // This option is created on activation.
     $existing_option = FALSE;
-    if ('fjwlws' != get_option('civicrm_activation_in_progress', 'fjwlws')) {
+    if ('fjwlws' !== get_option('civicrm_activation_in_progress', 'fjwlws')) {
       $existing_option = TRUE;
     }
 

--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -557,7 +557,7 @@ class CiviCRM_For_WordPress_Basepage {
     }
 
     // Construct title depending on separator location.
-    if ($separator_location == 'right') {
+    if ($separator_location === 'right') {
       $title = $this->basepage_title . " $separator " . get_bloginfo('name', 'display');
     }
     else {
@@ -636,21 +636,26 @@ class CiviCRM_For_WordPress_Basepage {
     // Access CiviCRM config object.
     $config = CRM_Core_Config::singleton();
 
+    // None of the following needs a nonce check.
+    // phpcs:disable WordPress.Security.NonceVerification.Recommended
+
     // Retain old logic when not using clean URLs.
     if (!$config->cleanURL) {
+
+      $civiwp = empty($_GET['civiwp']) ? '' : sanitize_text_field(wp_unslash($_GET['civiwp']));
+      $q = empty($_GET['q']) ? '' : sanitize_text_field(wp_unslash($_GET['q']));
 
       /*
        * It would be better to specify which params are okay to accept as the
        * canonical URLs, but this will work for the time being.
        */
-      if (empty($_GET['civiwp'])
-        || empty($_GET['q'])
-        || 'CiviCRM' !== $_GET['civiwp']) {
+      if (empty($civiwp)
+        || 'CiviCRM' !== $civiwp
+        || empty($q)) {
         return $canonical;
       }
-      $path = $_GET['q'];
-      unset($_GET['q']);
-      unset($_GET['civiwp']);
+      $path = $q;
+      unset($q, $_GET['q'], $civiwp, $_GET['civiwp']);
       $query = http_build_query($_GET);
 
     }
@@ -661,6 +666,8 @@ class CiviCRM_For_WordPress_Basepage {
       $query = http_build_query($_GET);
 
     }
+
+    // phpcs:enable WordPress.Security.NonceVerification.Recommended
 
     /*
      * We should, however, build the URL the way that CiviCRM expects it to be
@@ -687,12 +694,12 @@ class CiviCRM_For_WordPress_Basepage {
     $template_name = str_replace(trailingslashit(get_stylesheet_directory()), '', $template);
 
     // If the above fails, try parent theme.
-    if ($template_name == $template) {
+    if ($template_name === $template) {
       $template_name = str_replace(trailingslashit(get_template_directory()), '', $template);
     }
 
     // Bail in the unlikely event that the template name has not been found.
-    if ($template_name == $template) {
+    if ($template_name === $template) {
       return $template;
     }
 
@@ -713,7 +720,7 @@ class CiviCRM_For_WordPress_Basepage {
     $page_template = locate_template([$basepage_template]);
 
     // If not homepage and template is found.
-    if ('' != $page_template && !is_front_page()) {
+    if (!is_front_page() && !empty($page_template)) {
       return $page_template;
     }
 
@@ -740,7 +747,7 @@ class CiviCRM_For_WordPress_Basepage {
     $home_template = locate_template([$home_template_name]);
 
     // Use it if found.
-    if ('' != $home_template) {
+    if (!empty($home_template)) {
       return $home_template;
     }
 

--- a/includes/civicrm.shortcodes.modal.php
+++ b/includes/civicrm.shortcodes.modal.php
@@ -86,6 +86,7 @@ class CiviCRM_For_WordPress_Shortcodes_Modal {
     // Add button to selected WordPress Post Types, if allowed.
     if ($this->post_type_has_button()) {
 
+      // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
       $civilogo = file_get_contents(CIVICRM_PLUGIN_DIR . 'assets/images/civilogo.svg.b64');
 
       $url = admin_url('admin.php?page=CiviCRM&q=civicrm/shortcode&reset=1');
@@ -122,7 +123,7 @@ class CiviCRM_For_WordPress_Shortcodes_Modal {
     // Get screen object.
     $screen = get_current_screen();
 
-    // Bail if no post type (e.g. Ninja Forms)
+    // Bail if no post type - e.g. Ninja Forms.
     if (!isset($screen->post_type)) {
       return;
     }

--- a/includes/civicrm.users.php
+++ b/includes/civicrm.users.php
@@ -118,7 +118,7 @@ class CiviCRM_For_WordPress_Users {
    */
   public function check_permission($args) {
 
-    if ($args[0] != 'civicrm') {
+    if ($args[0] !== 'civicrm') {
       return FALSE;
     }
 
@@ -246,7 +246,7 @@ class CiviCRM_For_WordPress_Users {
    *
    * @since 4.6
    *
-   * @param $user_id The numerical ID of the WordPress user.
+   * @param int $user_id The numerical ID of the WordPress user.
    */
   public function delete_user_ufmatch($user_id) {
 
@@ -367,27 +367,32 @@ class CiviCRM_For_WordPress_Users {
    */
   public function get_civicrm_contact_type($default = NULL) {
 
+    // Nonce verification not necessary here.
+    // phpcs:disable WordPress.Security.NonceVerification.Recommended
+
     /*
      * Here we are creating a new Contact.
      * Get the Contact Type from the POST variables if any.
      */
     if (isset($_REQUEST['ctype'])) {
-      $ctype = $_REQUEST['ctype'];
+      $ctype = sanitize_text_field(wp_unslash($_REQUEST['ctype']));
     }
     elseif (
       isset($_REQUEST['edit']) &&
       isset($_REQUEST['edit']['ctype'])
     ) {
-      $ctype = $_REQUEST['edit']['ctype'];
+      $ctype = sanitize_text_field(wp_unslash($_REQUEST['edit']['ctype']));
     }
     else {
       $ctype = $default;
     }
 
+    // phpcs:enable WordPress.Security.NonceVerification.Recommended
+
     if (
-      $ctype != 'Individual' &&
-      $ctype != 'Organization' &&
-      $ctype != 'Household'
+      $ctype !== 'Individual' &&
+      $ctype !== 'Organization' &&
+      $ctype !== 'Household'
     ) {
       $ctype = $default;
     }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<ruleset name="CiviCRM.WordPress">
+
+	<!-- Add source codes in the report. -->
+	<arg value="s" />
+	<arg name="colors" />
+
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php" />
+	<file>.</file>
+
+	<rule ref="WordPress">
+
+		<!-- Allow slash-delimited hooks. -->
+		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores" />
+
+		<!-- Ignore docblock formatting. -->
+		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType" />
+
+		<!-- Allow CiviCRM control structures. -->
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd" />
+
+		<!-- Allow CiviCRM file headers. -->
+		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+		<exclude name="Squiz.Commenting.FileComment.WrongStyle" />
+
+		<!-- Ignore arrow or equals alignment. -->
+		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
+		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
+
+		<!-- Ignore file-naming conventions. -->
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+
+		<!-- Allow unreachable code in disabled Integration Page class for now. -->
+		<exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />
+
+		<!-- Ignore any other rules that conflict with CiviCRM and civilint. -->
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+		<exclude name="Generic.Commenting.DocComment.SpacingAfter" />
+		<exclude name="Generic.Metrics.NestingLevel.MaxExceeded" />
+		<exclude name="Generic.PHP.LowerCaseConstant.Found" />
+		<exclude name="Generic.WhiteSpace.ArbitraryParenthesesSpacing.SpaceAfterOpen" />
+		<exclude name="Generic.WhiteSpace.ArbitraryParenthesesSpacing.SpaceBeforeClose" />
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
+		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+		<exclude name="Squiz.Commenting.BlockComment.HasEmptyLineBefore" />
+		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
+		<exclude name="Squiz.PHP.CommentedOutCode.Found" />
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterOpen" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE" />
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.OpeningIndent" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
+		<exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions.NoSpacesAroundArrayKeys" />
+		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceAfterArrayOpener" />
+		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceBeforeArrayCloser" />
+		<exclude name="WordPress.Arrays.ArrayIndentation.ItemNotAligned" />
+		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine" />
+		<exclude name="WordPress.Arrays.ArrayIndentation.MultiLineArrayItemNotAligned" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase" />
+		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
+		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
+		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
+		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found" />
+
+	</rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="civicrm" />
+		</properties>
+	</rule>
+
+	<!-- Allow short array syntax. -->
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
+
+	<!-- Nesting levels. -->
+	<rule ref="Generic.Metrics.NestingLevel">
+		<properties>
+			<property name="absoluteNestingLevel" value="5" />
+		</properties>
+	</rule>
+
+	<!-- Ignore the CiviCRM Core subdirectory when present. -->
+	<exclude-pattern>civicrm/civicrm/*</exclude-pattern>
+
+	<!-- Ignore the following subdirectories for now. -->
+	<exclude-pattern>wp-cli/*</exclude-pattern>
+	<exclude-pattern>wp-rest/*</exclude-pattern>
+	<exclude-pattern>tests/*</exclude-pattern>
+
+</ruleset>


### PR DESCRIPTION
Overview
----------------------------------------
At present, this repo enforces the `civilint` codestyle - which is great to keep us all sane. However, there are many best practices when it comes to code that interacts with WordPress that are not covered by `civilint` but which can be determined using WordPress rulesets for `phpcs`. This PR adds a suitably-configured `phpcs.xml` file and updates the main plugin files to comply with it.

Technical Details
----------------------------------------
To test this PR, install the [WordPress Coding Standards for PHP_CodeSniffer](https://github.com/WordPress/WordPress-Coding-Standards) and make sure that the rulesets are known to `phpcs`, e.g.:

```sh
% phpcs -i
The installed coding standards are MySource, PEAR, PSR1, PSR2, PSR12, Squiz, Zend, WordPress, WordPress-Core, WordPress-Docs and WordPress-Extra
```

You should see no errors or warnings when running `phpcs` from the root directory of the repo.

I realise this is quite a substantial PR, but most of the changes are simple and fall broadly into the following categories:

* help text for translators
* avoiding clashes with WordPress globals
* using appropriate WordPress functions where applicable
* strict equality/inequality checks
* avoiding `extract()`
* consistency in docblocks 

The changes to the code do not alter the functionality of CIviCRM in WordPress - they only apply a number of recommendations from the WordPress rulesets. You can comment out individual `<exclude-pattern>` declarations in `phpcs.xml` to see how compatibility with `civilint` has been implemented. Where rules are deliberately ignored or disabled in code, you will find inline `phpcs:ignore` or or `php:disable` declarations in the appropriate places.