### PR TITLE
Fix component/shortcode not rendering

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -345,12 +345,7 @@ class CiviCRM_For_WordPress_Shortcodes {
         if (isset($this->shortcode_markup[$post->ID])) {
 
           // Set counter flag.
-          if (!isset($this->shortcode_in_post[$post->ID])) {
-            $this->shortcode_in_post[$post->ID] = 0;
-          }
-          else {
-            $this->shortcode_in_post[$post->ID]++;
-          }
+          $this->shortcode_in_post[$post->ID] = 0;
 
           // This Shortcode must have been rendered.
           return $this->shortcode_markup[$post->ID][$this->shortcode_in_post[$post->ID]];


### PR DESCRIPTION
Overview
----------------------------------------
The contributions component does not seem to render as a shortcode (`[civicrm component="contribution" id="1" mode="live"]`). It only works for me when I use the hijack option.

Technical Details
----------------------------------------
I'm not familiar with CiviCRM as a user and even less as a developer but this code is inside the `render_single` method. Can't we expect `$this->shortcode_markup[$post->ID]` to always be `1` and `$this->shortcode_in_post[$post->ID]` to subsequently be `0`? 
For some reason `$this->shortcode_in_post[$post->ID]` otherwise ends up being `2` and the shortcode content can not be found.

Comments
----------------------------------------
I'm sorry, this is rather a question than a fix (I think).

Why does `$this->shortcode_in_post[$post->ID]` evaluate as `2` for me even though there's just one shortcode on the entire page?

The code from this PR is working for me (right now).
