### PR TITLE
Use base page URL function to build links in multiple Shortcodes

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -486,54 +486,13 @@ class CiviCRM_For_WordPress_Shortcodes {
     // Default to no class.
     $class = '';
 
-    // Access CiviCRM config object.
-    $config = CRM_Core_Config::singleton();
-
     // Do we have multiple Shortcodes?
     if ($multiple !== 0) {
 
-      $links = [];
-      foreach ($args as $var => $arg) {
-        if (!empty($arg) && $var !== 'q') {
-          $links[] = $var . '=' . $arg;
-        }
-      }
-      $query = implode('&', $links);
-
-      // Params are: $absolute, $frontend, $forceBackend.
-      $base_url = CRM_Utils_System::getBaseUrl(TRUE, FALSE, FALSE);
-
-      // Init query parts.
-      $queryParts = [];
-
-      // When not using Clean URLs.
-      if (!$config->cleanURL) {
-
-        // Construct query parts.
-        $queryParts[] = 'civiwp=CiviCRM';
-        if (isset($args['q'])) {
-          $queryParts[] = 'q=' . $args['q'];
-        }
-        if (isset($query)) {
-          $queryParts[] = $query;
-        }
-
-        // Construct link.
-        $link = trailingslashit($base_url) . '?' . implode('&', $queryParts);
-
-      }
-      else {
-
-        // Clean URLs.
-        if (isset($args['q'])) {
-          $base_url = trailingslashit($base_url) . str_replace('civicrm/', '', $args['q']) . '/';
-        }
-        if (isset($query)) {
-          $queryParts[] = $query;
-        }
-        $link = $base_url . '?' . implode('&', $queryParts);
-
-      }
+      // Build link to Base Page.
+      $path = $args['q'];
+      unset($args['q']);
+      $link = civicrm_basepage_url($path, $args, TRUE, NULL, FALSE);
 
       // Add a class for styling purposes.
       $class = ' civicrm-shortcode-multiple';
@@ -589,7 +548,7 @@ class CiviCRM_For_WordPress_Shortcodes {
     $footer = '';
 
     // Test config object for setting.
-    if (1 === (int) $config->empoweredBy) {
+    if (1 === (int) CRM_Core_Config::singleton()->empoweredBy) {
 
       // Footer enabled - define it.
       $civi = __('CiviCRM.org - Growing and Sustaining Relationships', 'civicrm');


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #310. It occurred to me that now that the base page URL function is available, it can be used to generate the links to the Base Page when rendering multiple Shortcodes.

Before
----------------------------------------
Code that replicates what `CRM_Utils_System_WordPress::url()` does in a Base Page context generates the URL to the Base Page. Not Polylang-aware so all Base Page links point to the default locale.

After
----------------------------------------
Code replaced with call to base page URL function. As a bonus, this now works as expected with Polylang - i.e. Base Page URLs respect the locale of where the multiple Shortcodes are rendered.