### PR TITLE
Use unaliased Exception

### DIFF
--- a/wp-rest/Controller/Base.php
+++ b/wp-rest/Controller/Base.php
@@ -95,13 +95,13 @@ abstract class Base extends \WP_REST_Controller implements Endpoint_Interface {
    *
    * @since 5.25
    *
-   * @param string|\CiviCRM_API3_Exception|\WP_Error $error
+   * @param string|\CRM_Core_Exception|\WP_Error $error
    * @param mixed $data Error data
    * @return WP_Error $error
    */
   protected function civi_rest_error($error, $data = []) {
 
-    if ($error instanceof \CiviCRM_API3_Exception) {
+    if ($error instanceof \CRM_Core_Exception) {
 
       return $error->getExtraParams();
 

--- a/wp-rest/Controller/Rest.php
+++ b/wp-rest/Controller/Rest.php
@@ -124,7 +124,7 @@ class Rest extends Base {
     try {
       $items = civicrm_api3(...$params);
     }
-    catch (\CiviCRM_API3_Exception $e) {
+    catch (\CRM_Core_Exception $e) {
       $items = $this->civi_rest_error($e);
     }
 

--- a/wp-rest/Plugin.php
+++ b/wp-rest/Plugin.php
@@ -343,7 +343,7 @@ class Plugin {
       ]);
 
     }
-    catch (\CiviCRM_API3_Exception $e) {
+    catch (\CRM_Core_Exception $e) {
 
       return new \WP_Error(
         'civicrm_rest_api_error',


### PR DESCRIPTION
Overview
----------------------------------------
The class `CiviCRM_API3_Exception` has been deprecated since [CiviCRM 5.52](https://github.com/civicrm/civicrm-core/blob/6b7d77047024f4989d8fb2c9219d5ddf7e7161d0/api/Exception.php#L20) in favour of `CRM_Core_Exception`. This PR addresses this.