### PR TITLE
Add WPML integration for proper CiviCRM language generation dev/wordpress#133

### DIFF
--- a/includes/compatibility/civicrm.wpml.php
+++ b/includes/compatibility/civicrm.wpml.php
@@ -106,15 +106,15 @@ class CiviCRM_For_WordPress_Compat_WPML {
 
   }
 
- /**
-  * Checks WPML for CiviCRM Base Page matches.
-  *
-  * @since 5.70
-  *
-  * @param bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
-  * @param int $post_id The WordPress Post ID to check.
-  * @return bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
-  */
+  /**
+   * Checks WPML for CiviCRM Base Page matches.
+   *
+   * @since 5.70
+   *
+   * @param bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+   * @param int $post_id The WordPress Post ID to check.
+   * @return bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+   */
   public function basepage_match($is_basepage, $post_id) {
 
     // Bail if this is already the Base Page.
@@ -136,18 +136,18 @@ class CiviCRM_For_WordPress_Compat_WPML {
 
   }
 
- /**
-  * Filters the CiviCRM Base URL for the current language reported by WPML
-  *
-  * Only filters URLs that point to the front-end/back-end, since WordPress admin URLs are
-  * rewritten by WPML.
-  *
-  * @since 5.70
-  *
-  * @param str $url The URL as built by CiviCRM.
-  * @param bool $admin_request True if building an admin URL, false otherwise.
-  * @return str $url The URL as modified by WPML.
-  */
+  /**
+   * Filters the CiviCRM Base URL for the current language reported by WPML
+   *
+   * Only filters URLs that point to the front-end/back-end, since WordPress admin URLs are
+   * rewritten by WPML.
+   *
+   * @since 5.70
+   *
+   * @param str $url The URL as built by CiviCRM.
+   * @param bool $admin_request True if building an admin URL, false otherwise.
+   * @return str $url The URL as modified by WPML.
+   */
   public function base_url_filter($url, $admin_request) {
 
     // Skip when not defined.
@@ -182,14 +182,14 @@ class CiviCRM_For_WordPress_Compat_WPML {
 
   }
 
- /**
-  * Setup the rewrite rules for WPML.
-  *
-  * @since 5.70
-  *
-  * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
-  * @param WP_Post $basepage The Base Page post object.
-  */
+  /**
+   * Setup the rewrite rules for WPML.
+   *
+   * @since 5.70
+   *
+   * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
+   * @param WP_Post $basepage The Base Page post object.
+   */
   public function rewrite_rules_wpml($flush_rewrite_rules, $basepage) {
 
     // Bail if WPML is not present.
@@ -257,14 +257,14 @@ class CiviCRM_For_WordPress_Compat_WPML {
     }
   }
 
- /**
-  * icl_ls_languages WPML Filter
-  * Rewrite all CiviCRM URLs to contain the proper language structure based on the WPML settings
-  *
-  * @since 5.70
-  *
-  * @param array $languages passed by WPML to modify current path
-  */
+  /**
+   * icl_ls_languages WPML Filter
+   * Rewrite all CiviCRM URLs to contain the proper language structure based on the WPML settings
+   *
+   * @since 5.70
+   *
+   * @param array $languages passed by WPML to modify current path
+   */
   public function rewrite_civicrm_urls_wpml($languages) {
 
     // Get the post slug
@@ -316,17 +316,17 @@ class CiviCRM_For_WordPress_Compat_WPML {
     return $languages;
   }
 
- /**
-  * Remove Language from URL based on WPML configuration
-  *
-  * @since 5.70
-  *
-  * @param $url passed URL to strip language from
-  * @param object $sitepress WPML class
-  * @param int $wpml_negotiation language negotiation setting in WPML
-  *
-  * @return $url base page url without language
-  */
+  /**
+   * Remove Language from URL based on WPML configuration
+   *
+   * @since 5.70
+   *
+   * @param $url passed URL to strip language from
+   * @param object $sitepress WPML class
+   * @param int $wpml_negotiation language negotiation setting in WPML
+   *
+   * @return $url base page url without language
+   */
   private function wpml_remove_language_from_url($url, $sitepress, $wpml_negotiation) {
     $lang = $this->wpml_get_language_param_for_convert_url($sitepress);
     if ($lang) {
@@ -341,14 +341,14 @@ class CiviCRM_For_WordPress_Compat_WPML {
     return $url;
   }
 
- /**
-  * Get Language for WPML.
-  * This code was taken from the WPML source, because it couldn't be referenced directly
-  *
-  * @since 5.70
-  *
-  * @param object $sitepress reference to WPML class
-  */
+  /**
+   * Get Language for WPML.
+   * This code was taken from the WPML source, because it couldn't be referenced directly
+   *
+   * @since 5.70
+   *
+   * @param object $sitepress reference to WPML class
+   */
   private function wpml_get_language_param_for_convert_url($sitepress) {
     if (!empty($sitepress)) {
       if (isset($_GET['lang'])) {

--- a/includes/compatibility/civicrm.wpml.php
+++ b/includes/compatibility/civicrm.wpml.php
@@ -37,6 +37,15 @@ class CiviCRM_For_WordPress_Compat_WPML {
   public $civi;
 
   /**
+   * @var array
+   * Collected rewrites.
+   * @since 5.66
+   * @access private
+   */
+  private $rewrites = [];
+
+
+  /**
    * Instance constructor.
    *
    * @since 5.66
@@ -237,7 +246,7 @@ class CiviCRM_For_WordPress_Compat_WPML {
     };
 
     // Make collection unique and add remaining rewrite rules.
-    $rewrites = array_map('array_unique', $collected_rewrites);
+    $this->rewrites = array_map('array_unique', $collected_rewrites);
     if (!empty($rewrites)) {
       foreach ($rewrites as $post_id => $rewrite) {
         foreach ($rewrite as $path) {
@@ -249,7 +258,6 @@ class CiviCRM_For_WordPress_Compat_WPML {
         }
       }
     }
-    $this->rewrites = $rewrites;
 
     // Maybe force flush.
     if ($flush_rewrite_rules) {
@@ -328,7 +336,7 @@ class CiviCRM_For_WordPress_Compat_WPML {
    * @return $url base page url without language
    */
   private function wpml_remove_language_from_url($url, $sitepress, $wpml_negotiation) {
-    $lang = $this->wpml_get_language_param_for_convert_url($sitepress);
+    $lang = apply_filters( 'wpml_current_language', null );
     if ($lang) {
       if ($wpml_negotiation == 1) {
         $url = str_replace('/' . $lang . '/', '/', $url);
@@ -339,31 +347,6 @@ class CiviCRM_For_WordPress_Compat_WPML {
     }
 
     return $url;
-  }
-
-  /**
-   * Get Language for WPML.
-   * This code was taken from the WPML source, because it couldn't be referenced directly
-   *
-   * @since 5.70
-   *
-   * @param object $sitepress reference to WPML class
-   */
-  private function wpml_get_language_param_for_convert_url($sitepress) {
-    if (!empty($sitepress)) {
-      if (isset($_GET['lang'])) {
-        return filter_var($_GET['lang'], FILTER_SANITIZE_STRING);
-      }
-
-      if (is_multisite() && isset($_POST['lang'])) {
-        return filter_var($_POST['lang'], FILTER_SANITIZE_STRING);
-      }
-
-      if (is_multisite() && defined('SUBDOMAIN_INSTALL') && SUBDOMAIN_INSTALL) {
-        return $sitepress->get_current_language();
-      }
-    }
-    return NULL;
   }
 
 }

--- a/includes/compatibility/civicrm.wpml.php
+++ b/includes/compatibility/civicrm.wpml.php
@@ -74,7 +74,13 @@ class CiviCRM_For_WordPress_Compat_WPML {
     }
 
     // Register WPML compatibility callbacks.
+    add_action('civicrm_after_rewrite_rules', [$this, 'rewrite_rules_wpml'], 10, 2);
+    add_filter('icl_ls_languages', [$this, 'rewrite_civicrm_urls_wpml']);
+
+    // Register specific CiviCRM callbacks.
     add_filter('civicrm/core/locale', [$this, 'locale_filter'], 10, 2);
+    add_filter('civicrm/basepage/match', [$this, 'basepage_match'], 10, 2);
+    add_filter('civicrm/core/url/base', [$this, 'base_url_filter'], 10, 2);
 
   }
 
@@ -98,6 +104,259 @@ class CiviCRM_For_WordPress_Compat_WPML {
 
     return $locale;
 
+  }
+
+ /**
+   * Checks WPML for CiviCRM Base Page matches.
+   *
+   * @since 5.67
+   *
+   * @param bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+   * @param int $post_id The WordPress Post ID to check.
+   * @return bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+   */
+  public function basepage_match($is_basepage, $post_id) {
+
+    // Bail if this is already the Base Page.
+    if ($is_basepage) {
+      return $is_basepage;
+    }
+
+    // Bail if there are no rewrites.
+    if (empty($this->rewrites)) {
+      return $is_basepage;
+    }
+
+    // Check rewrites to see if we have a match with this $post_id
+    if (isset($this->rewrites[$post_id]) && !empty($this->rewrites[$post_id])) {
+      $is_basepage = TRUE;
+    }
+
+    return $is_basepage;
+
+  }
+
+ /**
+   * Filters the CiviCRM Base URL for the current language reported by WPML
+   *
+   * Only filters URLs that point to the front-end/back-end, since WordPress admin URLs are
+   * rewritten by WPML.
+   *
+   * @since 5.67
+   *
+   * @param str $url The URL as built by CiviCRM.
+   * @param bool $admin_request True if building an admin URL, false otherwise.
+   * @return str $url The URL as modified by WPML.
+   */
+  public function base_url_filter($url, $admin_request) {
+
+    // Skip when not defined.
+    if (empty($url)) {
+      return $url;
+    }
+
+    // Grab WPML language slug.
+    $slug = '';
+    $languages = apply_filters('wpml_active_languages', NULL);
+
+    foreach ($languages as $id => $language) {
+      if ($language['active']) {
+        $slug = $id;
+        break;
+      }
+    }
+
+    if (empty($slug)) {
+      return $url;
+    }
+
+    // Obtain lagnuage negotiation setting
+    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
+
+    // Build the modified URL.
+    global $sitepress;
+    $raw_url = $this->wpml_remove_language_from_url($url, $sitepress, $wpml_negotiation);
+    $language_url = $sitepress->convert_url($raw_url, $slug);
+
+    return $language_url;
+
+  }
+
+  /**
+   * Support WPML.
+   *
+   * @since 5.55.0
+   *
+   * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
+   * @param WP_Post $basepage The Base Page post object.
+   */
+  public function rewrite_rules_wpml($flush_rewrite_rules, $basepage) {
+
+    // Bail if WPML is not present.
+    if (!defined('ICL_SITEPRESS_VERSION')) {
+      return;
+    }
+
+    /*
+     * Collect all rewrite rules into an array.
+     *
+     * Because the array of specific Post IDs is added *after* the array of
+     * paths for the Base Page ID, those specific rewrite rules will "win" over
+     * the more general Base Page rules.
+     */
+    global $sitepress;
+    $collected_rewrites = [];
+
+    // Grab information about configuration
+    $wpml_active = apply_filters('wpml_active_languages', NULL);
+
+    // Obtain lagnuage negotiation setting
+    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
+
+    // Support prefixes for a single Base Page.
+    $basepage_url = get_permalink($basepage->ID);
+    $basepage_raw_url = $this->wpml_remove_language_from_url($basepage_url, $sitepress, $wpml_negotiation);
+    foreach ($wpml_active as $slug => $data) {
+      $language_url = $sitepress->convert_url($basepage_raw_url, $slug);
+      $parsed_url = wp_parse_url($language_url, PHP_URL_PATH);
+     $regex_path = substr($parsed_url, 1);
+
+      // Determine if there is a translation path
+      $post_id = apply_filters('wpml_object_id', $basepage->ID, 'page', FALSE, $slug);
+      if ($post_id == $basepage->ID) {
+        $collected_rewrites[$post_id][] = $regex_path;
+      } else {
+        $url = get_permalink($post_id);
+        $url = $sitepress->convert_url($url, $slug);
+        $parsed_url = wp_parse_url($url, PHP_URL_PATH);
+        $regex_path = substr($parsed_url, 1);
+        $collected_rewrites[$post_id][] = $regex_path;
+     }
+    };
+
+    // Make collection unique and add remaining rewrite rules.
+    $rewrites = array_map('array_unique', $collected_rewrites);
+    if (!empty($rewrites)) {
+      foreach ($rewrites as $post_id => $rewrite) {
+        foreach ($rewrite as $path) {
+          add_rewrite_rule(
+            '^' . $path . '([^?]*)?',
+            'index.php?page_id=' . $post_id . '&civiwp=CiviCRM&q=civicrm%2F$matches[1]',
+            'top'
+          );
+        }
+      }
+    }
+    $this->rewrites = $rewrites;
+
+    // Maybe force flush.
+    if ($flush_rewrite_rules) {
+      flush_rewrite_rules();
+    }
+  }
+
+  /**
+   * icl_ls_languages WPML Filter
+   *
+   * Rewrite all CiviCRM URLs to contain the proper language structure based on the WPML settings
+   *
+   * @param array $languages passed by WPML to modify current path
+   */
+  public function rewrite_civicrm_urls_wpml($languages) {
+
+    // Get the post slug
+    global $post;
+    $post_slug = isset($post->post_name) ? $post->post_name : '';
+    if (empty($post_slug) && isset($post->post_name)) {
+      $post_slug = $post->post_name;
+    }
+
+    // Get CiviCRM basepage slug
+    $civicrm_slug = apply_filters('civicrm_basepage_slug', 'civicrm');
+
+    // Obtain WPML lagnuage negotiation setting
+    $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
+
+    // If this is a CiviCRM Page then let's modify the actual path
+    if ($post_slug == $civicrm_slug) {
+      global $sitepress;
+      $current_url = explode("?", $_SERVER['REQUEST_URI']);
+      $civicrm_url = get_site_url(NULL, $current_url[0]);
+
+      // Remove language from path
+      $wpml_negotiation = apply_filters('wpml_setting', NULL, 'language_negotiation_type');
+      $civicrm_url = $this->wpml_remove_language_from_url($civicrm_url, $sitepress, $wpml_negotiation);
+
+      // Build query string
+      $qs = [];
+      parse_str($_SERVER["QUERY_STRING"], $qs);
+
+      // Strip any WPML languages if they exist
+      unset($qs['lang']);
+      $query = http_build_query($qs);
+
+      // Rebuild CiviCRM links for each language
+      foreach ($languages as &$language) {
+        $url = apply_filters('wpml_permalink', $civicrm_url, $language['language_code']);
+
+        if (!empty($query)) {
+          if ($wpml_negotiation == 3 && strpos($url, '?') !== FALSE) {
+            $language['url'] = $url . '&' . $query;
+          }
+          else {
+            $language['url'] = $url . '?' . $query;
+          }
+        }
+      }
+    }
+
+    return $languages;
+  }
+
+  /**
+   * Remove Language from URL based on WPML configuration
+   *
+   * @param $url passed URL to strip language from
+   * @param object $sitepress WPML class
+   * @param int $wpml_negotiation language negotiation setting in WPML
+   *
+   * @return $url base page url without language
+   */
+  private function wpml_remove_language_from_url($url, $sitepress, $wpml_negotiation) {
+    $lang = $this->wpml_get_language_param_for_convert_url($sitepress);
+    if ($lang) {
+      if ($wpml_negotiation == 1) {
+        $url = str_replace('/' . $lang . '/', '/', $url);
+      }
+      elseif ($wpml_negotiation == 3) {
+        $url = str_replace('lang=' . $lang, '', $url);
+      }
+    }
+
+    return $url;
+  }
+
+  /**
+   * Get Language for WPML.
+   * This code was taken from the WPML source, because it couldn't be referenced directly
+   *
+   * @param object $sitepress reference to WPML class
+   */
+  private function wpml_get_language_param_for_convert_url($sitepress) {
+    if (!empty($sitepress)) {
+      if (isset($_GET['lang'])) {
+        return filter_var($_GET['lang'], FILTER_SANITIZE_STRING);
+      }
+
+      if (is_multisite() && isset($_POST['lang'])) {
+        return filter_var($_POST['lang'], FILTER_SANITIZE_STRING);
+      }
+
+      if (is_multisite() && defined('SUBDOMAIN_INSTALL') && SUBDOMAIN_INSTALL) {
+        return $sitepress->get_current_language();
+      }
+    }
+    return NULL;
   }
 
 }

--- a/includes/compatibility/civicrm.wpml.php
+++ b/includes/compatibility/civicrm.wpml.php
@@ -107,14 +107,14 @@ class CiviCRM_For_WordPress_Compat_WPML {
   }
 
  /**
-   * Checks WPML for CiviCRM Base Page matches.
-   *
-   * @since 5.67
-   *
-   * @param bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
-   * @param int $post_id The WordPress Post ID to check.
-   * @return bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
-   */
+  * Checks WPML for CiviCRM Base Page matches.
+  *
+  * @since 5.70
+  *
+  * @param bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+  * @param int $post_id The WordPress Post ID to check.
+  * @return bool $is_basepage TRUE if the Post ID matches the Base Page ID, FALSE otherwise.
+  */
   public function basepage_match($is_basepage, $post_id) {
 
     // Bail if this is already the Base Page.
@@ -137,17 +137,17 @@ class CiviCRM_For_WordPress_Compat_WPML {
   }
 
  /**
-   * Filters the CiviCRM Base URL for the current language reported by WPML
-   *
-   * Only filters URLs that point to the front-end/back-end, since WordPress admin URLs are
-   * rewritten by WPML.
-   *
-   * @since 5.67
-   *
-   * @param str $url The URL as built by CiviCRM.
-   * @param bool $admin_request True if building an admin URL, false otherwise.
-   * @return str $url The URL as modified by WPML.
-   */
+  * Filters the CiviCRM Base URL for the current language reported by WPML
+  *
+  * Only filters URLs that point to the front-end/back-end, since WordPress admin URLs are
+  * rewritten by WPML.
+  *
+  * @since 5.70
+  *
+  * @param str $url The URL as built by CiviCRM.
+  * @param bool $admin_request True if building an admin URL, false otherwise.
+  * @return str $url The URL as modified by WPML.
+  */
   public function base_url_filter($url, $admin_request) {
 
     // Skip when not defined.
@@ -182,14 +182,14 @@ class CiviCRM_For_WordPress_Compat_WPML {
 
   }
 
-  /**
-   * Support WPML.
-   *
-   * @since 5.55.0
-   *
-   * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
-   * @param WP_Post $basepage The Base Page post object.
-   */
+ /**
+  * Setup the rewrite rules for WPML.
+  *
+  * @since 5.70
+  *
+  * @param bool $flush_rewrite_rules True if rules flushed, false otherwise.
+  * @param WP_Post $basepage The Base Page post object.
+  */
   public function rewrite_rules_wpml($flush_rewrite_rules, $basepage) {
 
     // Bail if WPML is not present.
@@ -219,19 +219,21 @@ class CiviCRM_For_WordPress_Compat_WPML {
     foreach ($wpml_active as $slug => $data) {
       $language_url = $sitepress->convert_url($basepage_raw_url, $slug);
       $parsed_url = wp_parse_url($language_url, PHP_URL_PATH);
-     $regex_path = substr($parsed_url, 1);
+      $regex_path = substr($parsed_url, 1);
 
       // Determine if there is a translation path
       $post_id = apply_filters('wpml_object_id', $basepage->ID, 'page', FALSE, $slug);
       if ($post_id == $basepage->ID) {
         $collected_rewrites[$post_id][] = $regex_path;
-      } else {
+      }
+      else {
         $url = get_permalink($post_id);
         $url = $sitepress->convert_url($url, $slug);
         $parsed_url = wp_parse_url($url, PHP_URL_PATH);
         $regex_path = substr($parsed_url, 1);
         $collected_rewrites[$post_id][] = $regex_path;
-     }
+      }
+
     };
 
     // Make collection unique and add remaining rewrite rules.
@@ -255,13 +257,14 @@ class CiviCRM_For_WordPress_Compat_WPML {
     }
   }
 
-  /**
-   * icl_ls_languages WPML Filter
-   *
-   * Rewrite all CiviCRM URLs to contain the proper language structure based on the WPML settings
-   *
-   * @param array $languages passed by WPML to modify current path
-   */
+ /**
+  * icl_ls_languages WPML Filter
+  * Rewrite all CiviCRM URLs to contain the proper language structure based on the WPML settings
+  *
+  * @since 5.70
+  *
+  * @param array $languages passed by WPML to modify current path
+  */
   public function rewrite_civicrm_urls_wpml($languages) {
 
     // Get the post slug
@@ -313,15 +316,17 @@ class CiviCRM_For_WordPress_Compat_WPML {
     return $languages;
   }
 
-  /**
-   * Remove Language from URL based on WPML configuration
-   *
-   * @param $url passed URL to strip language from
-   * @param object $sitepress WPML class
-   * @param int $wpml_negotiation language negotiation setting in WPML
-   *
-   * @return $url base page url without language
-   */
+ /**
+  * Remove Language from URL based on WPML configuration
+  *
+  * @since 5.70
+  *
+  * @param $url passed URL to strip language from
+  * @param object $sitepress WPML class
+  * @param int $wpml_negotiation language negotiation setting in WPML
+  *
+  * @return $url base page url without language
+  */
   private function wpml_remove_language_from_url($url, $sitepress, $wpml_negotiation) {
     $lang = $this->wpml_get_language_param_for_convert_url($sitepress);
     if ($lang) {
@@ -336,12 +341,14 @@ class CiviCRM_For_WordPress_Compat_WPML {
     return $url;
   }
 
-  /**
-   * Get Language for WPML.
-   * This code was taken from the WPML source, because it couldn't be referenced directly
-   *
-   * @param object $sitepress reference to WPML class
-   */
+ /**
+  * Get Language for WPML.
+  * This code was taken from the WPML source, because it couldn't be referenced directly
+  *
+  * @since 5.70
+  *
+  * @param object $sitepress reference to WPML class
+  */
   private function wpml_get_language_param_for_convert_url($sitepress) {
     if (!empty($sitepress)) {
       if (isset($_GET['lang'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/wordpress#133](https://lab.civicrm.org/dev/wordpress/-/issues/133)

Before
----------------------------------------
WPML was not serving the proper translated Event, Contribution and other CiviCRM public pages.

After
----------------------------------------

Translated pages are being shown. 🎆

Testing
----------------------------------------
- [x] ```Different domain per language```: Two domains WPML setup to redirect to say xyz-fr.org for French and xyz.org for English
- [x] ```Different languages in directories```: One domain with xyz.org/fr (French) and xyz.org (english)
- [x]  ```Different languages in directories```: One domain with xyz.org/fr (French) and xyz.org/en (english)
- [x] ```Different languages in directories```: One domain with xyz.org/fr (French) and xyz.org (english) but client changes the main civicrm page for each language like ```civicrm``` (English) and ```civicrm-fr``` for French
- [ ] ```Different languages added as a parameter```: (less likely used but :shrug: )  Example: xyz.org/?lang=fr
