### PR TITLE
Skip Base Page test when there is no Post object

### DIFF
--- a/includes/compatibility/civicrm.polylang.php
+++ b/includes/compatibility/civicrm.polylang.php
@@ -184,8 +184,13 @@ class CiviCRM_For_WordPress_Compat_Polylang {
       return $redirect_url;
     }
 
-    // Bail if this is not a Base Page.
+    // Bail if there is no Post object.
     $post = get_post();
+    if (!($post instanceof WP_Post)) {
+      return $redirect_url;
+    }
+
+    // Bail if this is not a Base Page.
     if (!empty($this->rewrites)) {
       foreach ($this->rewrites as $post_id => $rewrite) {
         if ($post_id === $post->ID) {


### PR DESCRIPTION
Overview
----------------------------------------
My logs seem to have a lot of entries of the following kind:

```
PHP Warning:  Attempt to read property "ID" on null in /path/to/civicrm/includes/compatibility/civicrm.polylang.php on line 191
```

This PR introduces a check to avoid such situations.

Before
----------------------------------------
PHP Warnings.

After
----------------------------------------
No PHP Warnings.
