### PR TITLE
Check permission before invoking CiviCRM

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -406,6 +406,13 @@ class CiviCRM_For_WordPress_Basepage {
         // Determine if the current Post is the Base Page.
         $is_basepage = $this->is_match($post->ID);
 
+        // Check permission.
+        $denied = TRUE;
+        $argdata = $this->civi->get_request_args();
+        if ($this->civi->users->check_permission($argdata['args'])) {
+          $denied = FALSE;
+        }
+
         // Skip when this is not the Base Page or when "Base Page mode" is not forced or not in "legacy mode".
         if ($is_basepage || $basepage_mode || $shortcode_mode === 'legacy') {
 
@@ -494,9 +501,8 @@ class CiviCRM_For_WordPress_Basepage {
     // Regardless of URL, load page template.
     add_filter('template_include', [$this, 'basepage_template'], 999);
 
-    // Check permission.
-    $argdata = $this->civi->get_request_args();
-    if (!$this->civi->users->check_permission($argdata['args'])) {
+    // Show content based on permission.
+    if ($denied) {
 
       // Do not show content.
       add_filter('the_content', [$this->civi->users, 'get_permission_denied']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue](https://lab.civicrm.org/dev/core/-/issues/5127) on Lab.

Before
----------------------------------------
`<form action="https://example.org/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fevent%2Fregister" ... >`


After
----------------------------------------
`<form action="https://example.org/civicrm/event/register/" ... >`

Technical Details
----------------------------------------
The new URL-building code in Core ultimately queries `CRM_Core_Config::singleton()->userFrameworkFrontend` to decide what `current:` should resolve to. This is (weirdly) set when checking access permissions. Previous URL-building code did not need to check this config property, so the change causes Base Page form submissions to point to the CiviCRM backend.

Affects CiviCRM 5.72.0.