### PR TITLE
573 perms

### DIFF
--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -406,6 +406,13 @@ class CiviCRM_For_WordPress_Basepage {
         // Determine if the current Post is the Base Page.
         $is_basepage = $this->is_match($post->ID);
 
+        // Check permission.
+        $denied = TRUE;
+        $argdata = $this->civi->get_request_args();
+        if ($this->civi->users->check_permission($argdata['args'])) {
+          $denied = FALSE;
+        }
+
         // Skip when this is not the Base Page or when "Base Page mode" is not forced or not in "legacy mode".
         if ($is_basepage || $basepage_mode || $shortcode_mode === 'legacy') {
 
@@ -494,9 +501,8 @@ class CiviCRM_For_WordPress_Basepage {
     // Regardless of URL, load page template.
     add_filter('template_include', [$this, 'basepage_template'], 999);
 
-    // Check permission.
-    $argdata = $this->civi->get_request_args();
-    if (!$this->civi->users->check_permission($argdata['args'])) {
+    // Show content based on permission.
+    if ($denied) {
 
       // Do not show content.
       add_filter('the_content', [$this->civi->users, 'get_permission_denied']);

--- a/includes/civicrm.basepage.php
+++ b/includes/civicrm.basepage.php
@@ -376,6 +376,13 @@ class CiviCRM_For_WordPress_Basepage {
     // Set a "found" flag.
     $basepage_found = FALSE;
 
+    // Check permission.
+    $denied = TRUE;
+    $argdata = $this->civi->get_request_args();
+    if ($this->civi->users->check_permission($argdata['args'])) {
+      $denied = FALSE;
+    }
+
     // Get the Shortcode Mode setting.
     $shortcode_mode = $this->civi->admin->get_shortcode_mode();
 
@@ -405,13 +412,6 @@ class CiviCRM_For_WordPress_Basepage {
 
         // Determine if the current Post is the Base Page.
         $is_basepage = $this->is_match($post->ID);
-
-        // Check permission.
-        $denied = TRUE;
-        $argdata = $this->civi->get_request_args();
-        if ($this->civi->users->check_permission($argdata['args'])) {
-          $denied = FALSE;
-        }
 
         // Skip when this is not the Base Page or when "Base Page mode" is not forced or not in "legacy mode".
         if ($is_basepage || $basepage_mode || $shortcode_mode === 'legacy') {

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: needle
 Tags: civicrm, crm
 Requires at least: 4.9
-Tested up to: 6.4
-Stable tag: 5.69
+Tested up to: 6.5
+Stable tag: 5.72
 License: AGPL3
 License URI: http://www.gnu.org/licenses/agpl-3.0.html
 


### PR DESCRIPTION
https://github.com/civicrm/civicrm-wordpress/pull/318

Overview
----------------------------------------
Fixes [this issue](https://lab.civicrm.org/dev/core/-/issues/5127) on Lab.

Before
----------------------------------------
`<form action="https://example.org/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fevent%2Fregister" ... >`


After
----------------------------------------
`<form action="https://example.org/civicrm/event/register/" ... >`

Technical Details
----------------------------------------
The new URL-building code in Core ultimately queries `CRM_Core_Config::singleton()->userFrameworkFrontend` to decide what `current:` should resolve to. This is (weirdly) set when checking access permissions. Previous URL-building code did not need to check this config property, so the change causes Base Page form submissions to point to the CiviCRM backend.

Affects CiviCRM 5.72.0.

https://github.com/civicrm/civicrm-wordpress/pull/320

Moves the permissions check so it always runs. Will catch an unlikely edge case where have_posts() returns 0. Better safe than sorry eh?

https://github.com/civicrm/civicrm-wordpress/pull/319 

Update readme.txt with tested up to and stable version

NFC - this is needed, but also looking to flag up test failures