### PR TITLE
Declare class property to avoid PHP warning

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -61,6 +61,14 @@ class CiviCRM_For_WordPress_Shortcodes {
   public $shortcode_in_post = [];
 
   /**
+   * @var array
+   * Simple flag to note that Shortcode parsing has occurred.
+   * @since 4.6
+   * @access public
+   */
+  public $shortcodes_parsed = FALSE;
+
+  /**
    * Instance constructor.
    *
    * @since 4.6


### PR DESCRIPTION
Overview
----------------------------------------
Trivial change to prevent PHP 8.2+ warnings in the logs when rendering Shortcodes.