### PR TITLE
NFC: Rewrite "is_page_request" method for comment

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -1477,7 +1477,7 @@ class CiviCRM_For_WordPress {
      * @since 5.74
      *
      * @param bool $non_page Boolean TRUE for requests that CiviCRM should not render as a "page".
-     * @param array $argdata Boolean The arguments and request string from query vars.
+     * @param array $argdata The arguments and request string from query vars.
      */
     $non_page = apply_filters('civicrm_is_non_page_request', $non_page, $argdata);
 

--- a/civicrm.php
+++ b/civicrm.php
@@ -1479,7 +1479,7 @@ class CiviCRM_For_WordPress {
      * @param bool $non_page Boolean TRUE for requests that CiviCRM should not render as a "page".
      * @param array $argdata Boolean The arguments and request string from query vars.
      */
-    $non_page = apply_filters('civicrm_is_page_request', $non_page, $argdata);
+    $non_page = apply_filters('civicrm_is_non_page_request', $non_page, $argdata);
 
     if ($non_page) {
       $is_page = FALSE;


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #324 to discuss how best to improve handling the distinction between CiviCRM "pages" and "non-pages".

I've refactored the `is_page_request()` method to make it a bit more obvious what's going on and added a filter that *could* be used to modify the outcome of the "non-page" checks if someone really wanted to do that.

I tend to agree with @colemanw that routes in CiviCRM should have metadata that determines this, but it may not even occur to Extension authors unless they test on WordPress and/or Joomla.

Anyway, at least having this PR here will keep eyes on the issue.