### PR TITLE
fix(wp-cli): confirm sentence

### DIFF
--- a/wp-cli/commands/command-db.php
+++ b/wp-cli/commands/command-db.php
@@ -74,7 +74,7 @@ class CLI_Tools_CiviCRM_Command_DB extends CLI_Tools_CiviCRM_Command {
   public function clear($args, $assoc_args) {
 
     // Let's give folks a chance to bail.
-    WP_CLI::confirm(WP_CLI::colorize('%GAre you sure you want to all CiviCRM entities from the database?%n'), $assoc_args);
+    WP_CLI::confirm(WP_CLI::colorize('%GAre you sure you want to clear all CiviCRM entities from the database?%n'), $assoc_args);
 
     // Get all CiviCRM database entities.
     $functions = $this->cividb_functions_get();


### PR DESCRIPTION
Overview
----------------------------------------
When running `wp civicrm core restore` there is typo in the confirm prompt. That is corrected in this PR.

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

<img width="571" alt="image" src="https://github.com/civicrm/civicrm-wordpress/assets/11808845/e69e52b3-8ae6-4bb0-aa2b-5af7dde78a20">


After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
<img width="612" alt="image" src="https://github.com/civicrm/civicrm-wordpress/assets/11808845/a962ec2c-a863-46fe-80e8-3f448e1d2cdc">


Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
Nothing as such.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
