### PR TITLE
NFC: Introduce Post Content filter prior to parsing Posts for Shortcodes

### DIFF
--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -155,6 +155,16 @@ class CiviCRM_For_WordPress_Shortcodes {
 
         global $post;
 
+        /**
+         * Filters the Post content.
+         *
+         * @since 5.75
+         *
+         * @param string $post_content The Post content.
+         * @param WP_Post $post The WordPress Post object.
+         */
+        $post->post_content = apply_filters('civicrm_prerender_post_content', $post->post_content, $post);
+
         // Check for existence of Shortcode in content.
         if (has_shortcode($post->post_content, 'civicrm')) {
 


### PR DESCRIPTION
Overview
----------------------------------------
Replaces #302.

Consider the following use case:

* I have data in an ACF Field on a Page that stores a Profile ID.
* I want that Profile to render on the Page.
* I want to build the Shortcode programatically have it parsed by the existing code.

At present, this either (1) can't be done or (2) is overly complicated to do.

Technical Details
----------------------------------------
A filter prior to the `has_shortcode()` call can make use of the existing Shortcode parsing and rendering functionality and can be used like this:

```php
/**
 * Adds some CiviCRM Shortcodes to the Post content.
 *
 * @param string $post_content The Post content.
 * @param WP_Post $post The WordPress Post object.
 * @return string $post_content The modified Post content.
 */
function my_civicrm_prerender_post_content( $post_content, $post ) {

	// Add a check for a relevant Post ID or Post Type here.

	// Add a CiviCRM Profile.
	$gid = get_field( 'profile_id', $post->ID );
	if ( ! empty( $gid ) ) {
		$post_content .= '[civicrm component="profile" gid="' . $gid . '" mode="create" hijack="0"]';
	}

	return $post_content;

}
add_filter( 'civicrm_prerender_post_content', 'my_civicrm_prerender_post_content', 10, 2 );
```

I have tested the above with additional Shortcodes (both invoking and non-invoking) in the actual content of the Page/Post. I also tested adding extra Afform Shortcodes to the above callback. Everything renders as expected.

Comments
----------------------------------------
I have marked this as NFC since it does not affect existing functionality unless the filter is used.