### PR TITLE
Prevent CiviCRM resources from loading when not in CiviCRM admin

### DIFF
--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -147,9 +147,6 @@ class CiviCRM_For_WordPress_Admin {
     // Modify the admin menu.
     add_action('admin_menu', [$this, 'add_menu_items'], 9);
 
-    // Add CiviCRM's resources in the admin header.
-    add_action('admin_head', [$this->civi, 'wp_head'], 50);
-
     // If settings file does not exist.
     if (!CIVICRM_INSTALLED) {
 
@@ -654,6 +651,9 @@ class CiviCRM_For_WordPress_Admin {
 
       // Add core resources prior to page load.
       add_action('load-' . $this->menu_page, [$this, 'admin_page_load']);
+
+      // Add CiviCRM's resources in the admin header.
+      add_action('admin_head-' . $this->menu_page, [$this->civi, 'wp_head'], 50);
 
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue on Lab](https://lab.civicrm.org/dev/wordpress/-/issues/151).

Before
----------------------------------------
CSS and JS from CiviCRM is loading on non-CiviCRM pages across WordPress admin.

After
----------------------------------------
CSS and JS from CiviCRM is restricted to CiviCRM pages.

Comments
----------------------------------------
It looks like I may have accidentally left a global scope hook callback in the code in [this PR](https://github.com/civicrm/civicrm-wordpress/pull/228).