### PR TITLE
revert 151-lab due to issues discovered with shortcode button

### DIFF
--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -147,6 +147,9 @@ class CiviCRM_For_WordPress_Admin {
     // Modify the admin menu.
     add_action('admin_menu', [$this, 'add_menu_items'], 9);
 
+    // Add CiviCRM's resources in the admin header.
+    add_action('admin_head', [$this->civi, 'wp_head'], 50);
+
     // If settings file does not exist.
     if (!CIVICRM_INSTALLED) {
 
@@ -651,9 +654,6 @@ class CiviCRM_For_WordPress_Admin {
 
       // Add core resources prior to page load.
       add_action('load-' . $this->menu_page, [$this, 'admin_page_load']);
-
-      // Add CiviCRM's resources in the admin header.
-      add_action('admin_head-' . $this->menu_page, [$this->civi, 'wp_head'], 50);
 
     }
     else {


### PR DESCRIPTION
Revert https://github.com/civicrm/civicrm-wordpress/pull/331

While the PR fixes the admin loading, any use of the civicrm shortcode modal (classic editor) will now fail.    Rather than create a new regression, reverting for now.

We will need to review the best way to load the assets (js and css) for WP as the current method will not easily cover the needs here. 