### PR TITLE
Enable theme compatibility checks for Shortcode rendering

### DIFF
--- a/assets/js/civicrm.options.js
+++ b/assets/js/civicrm.options.js
@@ -166,15 +166,18 @@
       // Assign properties.
       me.basepage_submit = $('#civicrm_basepage_submit');
       me.shortcode_submit = $('#civicrm_shortcode_submit');
+      me.theme_submit = $('#civicrm_theme_submit');
       me.email_submit = $('#civicrm_email_submit');
       me.permissions_submit = $('#civicrm_permissions_submit');
       me.cache_submit = $('#civicrm_cache_submit');
       me.basepage_select = $('#page_id');
       me.shortcode_select = $('#shortcode_mode');
+      me.theme_select = $('#theme_compatibility_mode');
       me.email_select = $('#sync_email');
       me.permissions_select = $('#permissions_role');
       me.basepage_selected = me.basepage_select.val();
       me.shortcode_selected = me.shortcode_select.val();
+      me.theme_selected = me.theme_select.val();
       me.email_selected = me.email_select.val();
 
       // Set status of Base Page submit button.
@@ -186,6 +189,10 @@
       // Set status of Shortcode Mode submit button.
       me.shortcode_submit.val(text);
       me.shortcode_submit.prop('disabled', true);
+
+      // Set status of Shortcode Theme Compatibility Mode submit button.
+      me.theme_submit.val(text);
+      me.theme_submit.prop('disabled', true);
 
       // Set status of Email Sync submit button.
       me.email_submit.val(text);
@@ -250,6 +257,28 @@
           text = CiviCRM_Options_Settings.get_localisation('update');
           me.shortcode_submit.val(text);
           me.shortcode_submit.prop('disabled', false);
+        }
+
+      });
+
+      /**
+       * Add an onchange event listener to the "Shortcode Theme Compatibility" section select.
+       *
+       * @param {Object} event The event object.
+       */
+      me.theme_select.on('change', function(event) {
+
+        var text;
+
+        // Enable/disable submit button.
+        if (me.theme_select.val() == me.theme_selected) {
+          text = CiviCRM_Options_Settings.get_localisation('saved');
+          me.theme_submit.val(text);
+          me.theme_submit.prop('disabled', true);
+        } else {
+          text = CiviCRM_Options_Settings.get_localisation('update');
+          me.theme_submit.val(text);
+          me.theme_submit.prop('disabled', false);
         }
 
       });
@@ -329,6 +358,34 @@
 
         // Submit setting to server.
         me.send('civicrm_shortcode', value, ajax_nonce);
+
+      });
+
+      /**
+       * Add a click event listener to the "Shortcode Theme Compatibility" section submit button.
+       *
+       * @param {Object} event The event object.
+       */
+      me.theme_submit.on('click', function(event) {
+
+        // Define vars.
+        var value = me.theme_select.val(),
+            ajax_nonce = me.theme_submit.data('security'),
+            saving = CiviCRM_Options_Settings.get_localisation('saving');
+
+        // Prevent form submission.
+        if (event.preventDefault) {
+          event.preventDefault();
+        }
+
+        // Modify button and select, then show spinner.
+        me.theme_submit.val(saving);
+        me.theme_submit.prop('disabled', true);
+        me.theme_select.prop('disabled', true);
+        $(this).next('.spinner').css('visibility', 'visible');
+
+        // Submit setting to server.
+        me.send('civicrm_theme_compatibility', value, ajax_nonce);
 
       });
 
@@ -511,6 +568,15 @@
           me.shortcode_selected = data.result;
           me.shortcode_select.prop('disabled', false);
 
+        } else if (data.section == 'theme') {
+
+          // Shortcode Mode section.
+          me.theme_submit.val(saved);
+          me.theme_submit.next('.spinner').css('visibility', 'hidden');
+          me.theme_select.val(data.result);
+          me.theme_selected = data.result;
+          me.theme_select.prop('disabled', false);
+
         } else if (data.section == 'email_sync') {
 
           // Email Sync section.
@@ -567,8 +633,18 @@
           me.shortcode_select.prop('disabled', false);
           $('.shortcode_notice').show();
           $('.shortcode_notice p').html(data.notice);
-          $('.shortcode_feedback').html(data.message);
           me.shortcode_selected = data.result;
+
+        } else if (data.section == 'theme') {
+
+          // Shortcode Mode section.
+          me.theme_submit.val(update);
+          me.theme_submit.next('.spinner').css('visibility', 'hidden');
+          me.theme_select.val(data.result);
+          me.theme_select.prop('disabled', false);
+          $('.theme_notice').show();
+          $('.theme_notice p').html(data.notice);
+          me.theme_selected = data.result;
 
         } else if (data.section == 'email_sync') {
 

--- a/assets/templates/metaboxes/metabox.options.theme.php
+++ b/assets/templates/metaboxes/metabox.options.theme.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+?><!-- assets/templates/metaboxes/metabox.options.shortcode.php -->
+<?php
+
+/**
+ * Before Shortcode section.
+ *
+ * @since 5.80
+ */
+do_action('civicrm/metabox/theme/pre');
+
+?>
+<div class="theme_notice notice notice-error inline" style="background-color: #f7f7f7; display: none;">
+  <p></p>
+</div>
+
+<p><?php printf(esc_html__('Some themes do not use "The Loop" to render page and post content. If a theme does not use The Loop, then it will not display CiviCRM Shortcodes. Try using the "Content Filter" check instead. If this does not work, you can use the %1$scivicrm_theme_compatibility_mode%2$s filter to implement your own check.', 'civicrm'), '<code>', '</code>'); ?></p>
+
+<label for="theme_compatibility_mode" class="screen-reader-text"><?php esc_html_e('Theme Compatibility', 'civicrm'); ?></label>
+<select name="theme_compatibility_mode" id="theme_compatibility_mode">
+  <option value="loop"<?php echo $selected_loop; ?>><?php esc_html_e('Check for The Loop', 'civicrm'); ?></option>
+  <option value="filter"<?php echo $selected_filter; ?>><?php esc_html_e('Check the Content Filter', 'civicrm'); ?></option>
+</select>
+
+<p class="submit">
+  <?php submit_button(esc_html__('Saved', 'civicrm'), 'primary hide-if-no-js', 'civicrm_theme_submit', FALSE, $options_ajax); ?>
+  <?php submit_button(esc_html__('Update', 'civicrm'), 'primary hide-if-js', 'civicrm_theme_post_submit', FALSE, $options_post); ?>
+  <span class="spinner"></span>
+</p>
+<br class="clear">
+<?php
+
+/**
+ * After Shortcode section.
+ *
+ * @since 5.80
+ */
+do_action('civicrm/metabox/theme/post');

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -970,4 +970,39 @@ class CiviCRM_For_WordPress_Admin {
     return ['legacy', 'modern'];
   }
 
+  /**
+   * Gets the CiviCRM Shortcode Theme Compatibility Mode.
+   *
+   * Defaults to "loop" to preserve existing behaviour.
+   *
+   * @since 5.80
+   *
+   * @return string $theme_compatibility_mode The Shortcode Theme Compatibility Mode: either 'loop' or 'filter'.
+   */
+  public function get_theme_compatibility_mode() {
+    return get_option('civicrm_theme_compatibility_mode', 'loop');
+  }
+
+  /**
+   * Sets the CiviCRM Shortcode Theme Compatibility Mode.
+   *
+   * @since 5.80
+   *
+   * @param string $theme_compatibility_mode The Shortcode Theme Compatibility Mode: either 'loop' or 'filter'.
+   */
+  public function set_theme_compatibility_mode($theme_compatibility_mode) {
+    update_option('civicrm_theme_compatibility_mode', $theme_compatibility_mode);
+  }
+
+  /**
+   * Gets the array of CiviCRM Shortcode Theme Compatibility Modes.
+   *
+   * @since 5.80
+   *
+   * @return array $theme_compatibility_modes The array of Shortcode Theme Compatibility Modes.
+   */
+  public function get_theme_compatibility_modes() {
+    return ['loop', 'filter'];
+  }
+
 }

--- a/includes/civicrm.shortcodes.php
+++ b/includes/civicrm.shortcodes.php
@@ -360,13 +360,38 @@ class CiviCRM_For_WordPress_Shortcodes {
       return $shortcode;
     }
 
+    // Get the Shortcode Theme Compatibility setting.
+    $theme_mode = $this->civi->admin->get_theme_compatibility_mode();
+
+    // Check the chosen theme compatibility scenario.
+    if ($theme_mode === 'loop') {
+      $theme_check = in_the_loop();
+    }
+    else {
+      $theme_check = ('the_content' === current_filter()) ? TRUE : FALSE;
+    }
+
+    /**
+     * Filters the chosen theme compatibility check.
+     *
+     * If neither 'loop' nor 'filter' work for your theme, you can implement a custom
+     * theme compatibility check using this filter. You will most likely have to dig
+     * into how your theme renders content to find out what check to implement.
+     *
+     * @since 5.80
+     *
+     * @param bool $theme_check True if the check has passed, false otherwise.
+     * @param bool $theme_mode The Shortcode Theme Compatibility setting.
+     */
+    $theme_check = apply_filters('civicrm_theme_compatibility_mode', $theme_check, $theme_mode);
+
     /*
      * Check if we've already rendered this Shortcode by parsing post content in
      * The Loop in `prerender()` above. CiviCRM Shortcodes that are rendered via
      * `do_shortcode('[civicrm ...]')` elsewhere (e.g. in a template) will never
      * have been prerendered and cannot be present in the Shortcode markup array.
      */
-    if (in_the_loop()) {
+    if ($theme_check) {
       if (is_object($post)) {
         if (!empty($this->shortcode_markup)) {
           if (isset($this->shortcode_markup[$post->ID])) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [this issue on Lab](https://lab.civicrm.org/dev/core/-/issues/5553)

Before
----------------------------------------
Rendering Shortcodes only checks `in_the_loop()` to see if the Shortcode has been pre-rendered. This fails for some themes.

After
----------------------------------------
There is a new setting which allows a choice of checking `in_the_loop()` or whether `the_content` is the filter that is currently running. One of these settings *should* work for the majority of themes. If neither works, then there is a `civicrm_theme_compatibility_mode` filter through which custom theme compatibility checks can be made.

<img width="814" alt="Screenshot 2024-11-13 at 13 43 33" src="https://github.com/user-attachments/assets/26d612ec-0804-47f4-84d0-6a7a169ef928">

Technical Details
----------------------------------------
An example of when neither option works would be when trying to render a Shortcode in an ACF "WYSIWYG" Field. ACF mimics what WordPress does using the `acf_the_content` filter when rendering the "WYSIWYG" Field on the front end, so the following code *should* work:

```php
/**
 * Applies a custom theme compatibility check.
 *
 * @param bool $theme_check True if the check has passed, false otherwise.
 * @param bool $theme_mode The Shortcode Theme Compatibility setting.
 * @return bool $theme_check True if the custom check has passed, false otherwise.
 */
function my_civicrm_theme_compatibility_mode( $theme_mode, $theme_check ) {

  // Render if the ACF content filter is the current filter.
  $filter_check = ('acf_the_content' === current_filter()) ? TRUE : FALSE;
  if ($filter_check) {
    $theme_mode = TRUE;
  }

  return $theme_mode;

}
add_filter( 'civicrm_theme_compatibility_mode', 'my_civicrm_theme_compatibility_mode', 10, 2 );

```

Note that the above code would be dependent on Shortcode pre-rendering e.g. via the `civicrm_prerender_post_content` filter and CiviCRM resources having been properly added.