### PR TITLE
Set minimum PHP version needed is 8.0

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -4,7 +4,7 @@
  * Description: CiviCRM - Growing and Sustaining Relationships
  * Version: 4.7
  * Requires at least: 4.9
- * Requires PHP:      7.4
+ * Requires PHP:      8.0
  * Author: CiviCRM LLC
  * Author URI: https://civicrm.org/
  * Plugin URI: https://docs.civicrm.org/sysadmin/en/latest/install/wordpress/
@@ -65,7 +65,7 @@ if (!defined('CIVICRM_PLUGIN_DIR')) {
  * @see CiviWP\PhpVersionTest::testConstantMatch()
  */
 if (!defined('CIVICRM_WP_PHP_MINIMUM')) {
-  define('CIVICRM_WP_PHP_MINIMUM', '7.4.0');
+  define('CIVICRM_WP_PHP_MINIMUM', '8.0.0');
 }
 
 /*


### PR DESCRIPTION
Overview
----------------------------------------
To be merged with https://github.com/civicrm/civicrm-core/pull/31652 or https://github.com/civicrm/civicrm-core/pull/31765 is merged

ping @eileenmcnaughton @colemanw @demeritcowboy @kcristiano 

Before
----------------------------------------
Minimum PHP version 7.4

After
----------------------------------------
Minimum PHP version is 8.0

