### PR TITLE
Fix intermittent ExpiredToken error when Iframe patches applied

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -257,8 +257,8 @@ class CiviCRM_For_WordPress {
         include_once CIVICRM_PLUGIN_DIR . 'wp-cli/wp-cli-civicrm.php';
       }
 
-      define('CIVICRM_IFRAME', self::$instance->is_iframe());
-      if (CIVICRM_IFRAME) {
+      if (self::$instance->is_iframe()) {
+        define('CIVICRM_IFRAME', 1);
         // Must run before WP starts processing cookies.
         self::$instance->activate_iframe();
       }
@@ -1270,7 +1270,7 @@ class CiviCRM_For_WordPress {
     }
 
     // Do the business.
-    if (CIVICRM_IFRAME && \Civi::service('iframe.router')->getLayout() !== 'cms') {
+    if (defined('CIVICRM_IFRAME') && CIVICRM_IFRAME && \Civi::service('iframe.router')->getLayout() !== 'cms') {
       \Civi::service('iframe.router')->invoke([
         'route' => implode('/', $argdata['args']),
         'printPage' => function ($content) {


### PR DESCRIPTION
Overview
----------------------------------------
Since enabling iframe on WordPress the site has been getting occasional crashes on the admin backend with "Firebase\JWT\ExpiredException: Expired token".
Eg. I triggered it by clicking "save" on a settings page. Definitely not running in an iframe.

Before
----------------------------------------
Crashes sometimes

After
----------------------------------------
Shouldn't crash. Follows identical pattern to other entrypoints.

Technical Details
----------------------------------------
All other entrypoints ONLY define `CIVICRM_IFRAME` it is is TRUE/1 - eg. see https://github.com/civicrm/civicrm-core/blob/master/ext/iframe/Civi/Iframe/EntryPoint/Drupal8.php#L17

But the WordPress implementation always defines `CIVICRM_IFRAME` and sets it to either TRUE or FALSE. This is problematic because all consumers of `CIVICRM_IFRAME` check if it is defined and do not check the value - eg. see https://github.com/civicrm/civicrm-core/blob/master/ext/iframe/Civi/Iframe/Cosession.php#L50

```
Firebase\JWT\ExpiredException: Expired token"
  "code" => null
  "exception" => Civi\Crypto\Exception\CryptoException {#15031
    #message: "Firebase\JWT\ExpiredException: Expired token"
    #code: 0
    #file: "/var/www/vhosts/xxx.org/wp-content/plugins/civicrm/civicrm/Civi/Crypto/CryptoJwt.php"
    #line: 101
    #cause: null
    -_trace: null
    -errorData: array:1 [
      "error_code" => 0
    ]
    trace: {
      /var/www/vhosts/xxx.org/wp-content/plugins/civicrm/civicrm/Civi/Crypto/CryptoJwt.php:101 {
        Civi\Crypto\CryptoJwt->decode($token, $keyTag = 'SIGN')
        ›   // Keep our signature independent of the implementation.
        ›   throw new CryptoException(get_class($e) . ': ' . $e->getMessage());
        › }
      }
      /var/www/vhosts/xxx.org/wp-content/plugins/civicrm/civicrm/ext/iframe/Civi/Iframe/Cosession.php:204 { …}
      /var/www/vhosts/xxx.org/wp-content/plugins/civicrm/civicrm/ext/iframe/Civi/Iframe/Cosession.php:70 { …}
      /var/www/vhosts/xxx.org/wp-content/plugins/civicrm/civicrm/ext/iframe/Civi/Iframe/Cosession.php:147 { …}
```

Comments
----------------------------------------
