### PR TITLE
WPML Rewrites defaulting to last language prefix found

### DIFF
--- a/includes/compatibility/civicrm.wpml.php
+++ b/includes/compatibility/civicrm.wpml.php
@@ -155,12 +155,14 @@ class CiviCRM_For_WordPress_Compat_WPML {
       $converted_url = $sitepress->convert_url($url, $slug);
       $parsed_url = wp_parse_url($converted_url, PHP_URL_PATH);
       $regex_path_converted = substr($parsed_url, 1);
-
-      $collected_rewrites[$basepage->ID][] = $regex_path;
-      $collected_rewrites[$basepage->ID][] = $regex_path_converted;
-      $collected_rewrites[$post_id][] = $regex_path;
-      $collected_rewrites[$post_id][] = $regex_path_converted;
-
+      if ($basepage->ID == $post_id) {
+        $collected_rewrites[$basepage->ID][] = $regex_path;
+        $collected_rewrites[$basepage->ID][] = $regex_path_converted;
+      }
+      else {
+        // Add only the language specific regex path
+        $collected_rewrites[$post_id][] = $regex_path_converted;
+      }
     }
 
     // Make collection unique and add remaining rewrite rules.


### PR DESCRIPTION
Based on dev/wordpress#153

<h2 dir="auto" data-sourcepos="1:1-1:14">Description</h2>
<p dir="auto" data-sourcepos="3:1-3:150">Recently, we have been having a problem with the base CiviCRM page not rendering paths like <code data-sourcepos="3:94-3:107">event/info/...</code> properly except for the translated pages.</p>
<p dir="auto" data-sourcepos="5:1-5:112">After further research, I found that the rewrites were defaulting to the page id of the translated CiviCRM page.</p>

Rewrite path | Rewrite | Source
-- | -- | --
^civicrm/([^?]*)? | index.php?page_id=9439&civiwp=CiviCRM&q=civicrm%2F$matches | other
  | [1] |  
^fr/civicrm/([^?]*)? | index.php?page_id=9439&civiwp=CiviCRM&q=civicrm%2F$matches | other
  | [1] |  


<p dir="auto" data-sourcepos="14:1-14:102">The first path <code data-sourcepos="14:17-14:33">^civicrm/([^?]*)?</code> should be pointing to the Base Page not the actual translated page.</p>
<h2 dir="auto" data-sourcepos="16:1-16:8">
<a id="user-content-setup" class="anchor after:!gl-hidden" aria-hidden="true" href="#setup"></a>Setup</h2>
<ul dir="auto" data-sourcepos="18:1-24:0">
<li data-sourcepos="18:1-18:26">English Canada (default)</li>
<li data-sourcepos="19:1-19:15">French Canada</li>
<li data-sourcepos="20:1-20:36">CiviCRM Languages added (as above)</li>
<li data-sourcepos="21:1-21:41">Mapping codes above to CiviCRM language</li>

## After

Essentially, what this does is not to add the language translation redirect to the `basepage ID` and vic versa. In my scenario this is totally messing with the translation of CiviCRM and causing a page not found on the translated link.

Specifically

```
 $collected_rewrites[$post_id][] = $regex_path;
 ```

and also for the other languages

```
 $collected_rewrites[$basepage->ID][] = $regex_path_converted;
```