### PR TITLE
Add new WP CiviCRM setting option that allows for controlling whether…

### DIFF
--- a/assets/js/civicrm.options.js
+++ b/assets/js/civicrm.options.js
@@ -170,15 +170,18 @@
       me.email_submit = $('#civicrm_email_submit');
       me.permissions_submit = $('#civicrm_permissions_submit');
       me.cache_submit = $('#civicrm_cache_submit');
+      me.auto_sign_in_user_submit = $('#civicrm_auto_sign_in_user_submit');
       me.basepage_select = $('#page_id');
       me.shortcode_select = $('#shortcode_mode');
       me.theme_select = $('#theme_compatibility_mode');
       me.email_select = $('#sync_email');
       me.permissions_select = $('#permissions_role');
+      me.auto_sign_in_user_select = $('#auto_sign_in_user');
       me.basepage_selected = me.basepage_select.val();
       me.shortcode_selected = me.shortcode_select.val();
       me.theme_selected = me.theme_select.val();
       me.email_selected = me.email_select.val();
+      me.auto_sign_in_user_selected = me.auto_sign_in_user_select.val();
 
       // Set status of Base Page submit button.
       me.basepage_submit.prop('disabled', true);
@@ -197,6 +200,10 @@
       // Set status of Email Sync submit button.
       me.email_submit.val(text);
       me.email_submit.prop('disabled', true);
+
+      // Set status of the Automatically Sign In User submit button.
+      me.auto_sign_in_user_submit.val(text);
+      me.auto_sign_in_user_submit.prop('disabled', true);
 
     };
 
@@ -306,6 +313,27 @@
       });
 
       /**
+       * Add an onchange event listener to the "Email Sync" section select.
+       *
+       * @param {Object} event The event object.
+       */
+      me.auto_sign_in_user_select.on('change', function(event) {
+
+        var text;
+
+        // Enable/disable submit button.
+        if (me.auto_sign_in_user_select.val() == me.auto_sign_in_user_selected) {
+          text = CiviCRM_Options_Settings.get_localisation('saved');
+          me.auto_sign_in_user_submit.val(text);
+          me.auto_sign_in_user_submit.prop('disabled', true);
+        } else {
+          text = CiviCRM_Options_Settings.get_localisation('update');
+          me.auto_sign_in_user_submit.val(text);
+          me.auto_sign_in_user_submit.prop('disabled', false);
+        }
+      });
+
+      /**
        * Add a click event listener to the "Basepage" section submit button.
        *
        * @param {Object} event The event object.
@@ -314,8 +342,8 @@
 
         // Define vars.
         var value = me.basepage_select.val(),
-            ajax_nonce = me.basepage_submit.data('security'),
-            saving = CiviCRM_Options_Settings.get_localisation('saving');
+          ajax_nonce = me.basepage_submit.data('security'),
+          saving = CiviCRM_Options_Settings.get_localisation('saving');
 
         // Prevent form submission.
         if (event.preventDefault) {
@@ -342,8 +370,8 @@
 
         // Define vars.
         var value = me.shortcode_select.val(),
-            ajax_nonce = me.shortcode_submit.data('security'),
-            saving = CiviCRM_Options_Settings.get_localisation('saving');
+          ajax_nonce = me.shortcode_submit.data('security'),
+          saving = CiviCRM_Options_Settings.get_localisation('saving');
 
         // Prevent form submission.
         if (event.preventDefault) {
@@ -370,8 +398,8 @@
 
         // Define vars.
         var value = me.theme_select.val(),
-            ajax_nonce = me.theme_submit.data('security'),
-            saving = CiviCRM_Options_Settings.get_localisation('saving');
+          ajax_nonce = me.theme_submit.data('security'),
+          saving = CiviCRM_Options_Settings.get_localisation('saving');
 
         // Prevent form submission.
         if (event.preventDefault) {
@@ -398,8 +426,8 @@
 
         // Define vars.
         var value = me.email_select.val(),
-            ajax_nonce = me.email_submit.data('security'),
-            saving = CiviCRM_Options_Settings.get_localisation('saving');
+          ajax_nonce = me.email_submit.data('security'),
+          saving = CiviCRM_Options_Settings.get_localisation('saving');
 
         // Prevent form submission.
         if (event.preventDefault) {
@@ -426,8 +454,8 @@
 
         // Define vars.
         var value = me.permissions_select.val(),
-            ajax_nonce = me.permissions_submit.data('security'),
-            refreshing = CiviCRM_Options_Settings.get_localisation('refreshing');
+          ajax_nonce = me.permissions_submit.data('security'),
+          refreshing = CiviCRM_Options_Settings.get_localisation('refreshing');
 
         // Prevent form submission.
         if (event.preventDefault) {
@@ -454,7 +482,7 @@
 
         // Define vars.
         var ajax_nonce = me.cache_submit.data('security'),
-            clearing = CiviCRM_Options_Settings.get_localisation('clearing');
+          clearing = CiviCRM_Options_Settings.get_localisation('clearing');
 
         // Prevent form submission.
         if (event.preventDefault) {
@@ -468,6 +496,34 @@
 
         // Submit request to server.
         me.send('civicrm_clear_caches', 1, ajax_nonce);
+
+      });
+
+      /**
+       * Add a click event listener to the "Automatically Sign In User" section submit button.
+       *
+       * @param {Object} event The event object.
+       */
+      me.auto_sign_in_user_submit.on('click', function(event) {
+
+        // Define vars.
+        var value = me.auto_sign_in_user_select.val(),
+          ajax_nonce = me.auto_sign_in_user_submit.data('security'),
+          saving = CiviCRM_Options_Settings.get_localisation('saving');
+
+        // Prevent form submission.
+        if (event.preventDefault) {
+          event.preventDefault();
+        }
+
+        // Modify button and select, then show spinner.
+        me.auto_sign_in_user_submit.val(saving);
+        me.auto_sign_in_user_submit.prop('disabled', true);
+        me.auto_sign_in_user_select.prop('disabled', true);
+        $(this).next('.spinner').css('visibility', 'visible');
+
+        // Submit request to server.
+        me.send('civicrm_auto_sign_in_user', value, ajax_nonce);
 
       });
 
@@ -538,14 +594,14 @@
 
       // Declare vars.
       var saved = CiviCRM_Options_Settings.get_localisation('saved'),
-          update = CiviCRM_Options_Settings.get_localisation('update'),
-          clearing = CiviCRM_Options_Settings.get_localisation('clearing'),
-          refresh = CiviCRM_Options_Settings.get_localisation('refresh'),
-          cache = CiviCRM_Options_Settings.get_localisation('cache');
+        update = CiviCRM_Options_Settings.get_localisation('update'),
+        clearing = CiviCRM_Options_Settings.get_localisation('clearing'),
+        refresh = CiviCRM_Options_Settings.get_localisation('refresh'),
+        cache = CiviCRM_Options_Settings.get_localisation('cache');
 
       if (data.saved) {
 
-		// Success!
+        // Success!
         if (data.section == 'basepage') {
 
           // Base Page section.
@@ -607,102 +663,120 @@
           me.cache_submit.prop('disabled', false);
           me.cache_submit.next('.spinner').css('visibility', 'hidden');
 
-        }
-
-      } else {
-
-		// Failure.
-        if (data.section == 'basepage') {
-
-          // Base Page section.
-          me.basepage_submit.val(update);
-          me.basepage_submit.next('.spinner').css('visibility', 'hidden');
-          me.basepage_select.val(data.result);
-          me.basepage_select.prop('disabled', false);
-          $('.basepage_notice').show();
-          $('.basepage_notice p').html(data.notice);
-          $('.basepage_feedback').html(data.message);
-          me.basepage_selected = data.result;
-
-        } else if (data.section == 'shortcode') {
-
+        } else if (data.section == 'auto_sign_in_user') {
           // Shortcode Mode section.
-          me.shortcode_submit.val(update);
-          me.shortcode_submit.next('.spinner').css('visibility', 'hidden');
-          me.shortcode_select.val(data.result);
-          me.shortcode_select.prop('disabled', false);
-          $('.shortcode_notice').show();
-          $('.shortcode_notice p').html(data.notice);
-          me.shortcode_selected = data.result;
+          me.auto_sign_in_user_submit.val(saved);
+          me.auto_sign_in_user_submit.next('.spinner').css('visibility', 'hidden');
+          me.auto_sign_in_user_select.val(data.result);
+          me.auto_sign_in_user_selected = data.result;
+          me.auto_sign_in_user_select.prop('disabled', false);
+      }
 
-        } else if (data.section == 'theme') {
+    } else {
 
-          // Shortcode Mode section.
-          me.theme_submit.val(update);
-          me.theme_submit.next('.spinner').css('visibility', 'hidden');
-          me.theme_select.val(data.result);
-          me.theme_select.prop('disabled', false);
-          $('.theme_notice').show();
-          $('.theme_notice p').html(data.notice);
-          me.theme_selected = data.result;
+      // Failure.
+      if (data.section == 'basepage') {
 
-        } else if (data.section == 'email_sync') {
+        // Base Page section.
+        me.basepage_submit.val(update);
+        me.basepage_submit.next('.spinner').css('visibility', 'hidden');
+        me.basepage_select.val(data.result);
+        me.basepage_select.prop('disabled', false);
+        $('.basepage_notice').show();
+        $('.basepage_notice p').html(data.notice);
+        $('.basepage_feedback').html(data.message);
+        me.basepage_selected = data.result;
 
-          // Email Sync section.
-          me.email_submit.val(update);
-          me.email_submit.next('.spinner').css('visibility', 'hidden');
-          me.email_select.val(data.result);
-          me.email_select.prop('disabled', false);
-          $('.email_notice').show();
-          $('.email_notice p').html(data.notice);
-          $('.email_feedback').html(data.message);
-          me.email_selected = data.result;
+      } else if (data.section == 'shortcode') {
 
-        } else if (data.section == 'refresh_permissions') {
+        // Shortcode Mode section.
+        me.shortcode_submit.val(update);
+        me.shortcode_submit.next('.spinner').css('visibility', 'hidden');
+        me.shortcode_select.val(data.result);
+        me.shortcode_select.prop('disabled', false);
+        $('.shortcode_notice').show();
+        $('.shortcode_notice p').html(data.notice);
+        me.shortcode_selected = data.result;
 
-          // Permissions and Capabilities section.
-          me.permissions_submit.val(refresh);
-          me.permissions_submit.next('.spinner').css('visibility', 'hidden');
-          me.permissions_submit.prop('disabled', false);
-          $('.permissions_success').hide();
-          $('.permissions_error').show();
-          $('.permissions_error p').html(data.notice);
+      } else if (data.section == 'theme') {
 
-        } else if (data.section == 'clear_caches') {
+        // Shortcode Mode section.
+        me.theme_submit.val(update);
+        me.theme_submit.next('.spinner').css('visibility', 'hidden');
+        me.theme_select.val(data.result);
+        me.theme_select.prop('disabled', false);
+        $('.theme_notice').show();
+        $('.theme_notice p').html(data.notice);
+        me.theme_selected = data.result;
 
-          // Clear Caches section.
-          me.cache_submit.val(cache);
-          me.cache_submit.next('.spinner').css('visibility', 'hidden');
-          me.cache_submit.prop('disabled', false);
-          $('.caches_success').hide();
-          $('.caches_error').show();
-          $('.caches_error p').html(data.notice);
+      } else if (data.section == 'email_sync') {
 
-        }
+        // Email Sync section.
+        me.email_submit.val(update);
+        me.email_submit.next('.spinner').css('visibility', 'hidden');
+        me.email_select.val(data.result);
+        me.email_select.prop('disabled', false);
+        $('.email_notice').show();
+        $('.email_notice p').html(data.notice);
+        $('.email_feedback').html(data.message);
+        me.email_selected = data.result;
+
+      } else if (data.section == 'refresh_permissions') {
+
+        // Permissions and Capabilities section.
+        me.permissions_submit.val(refresh);
+        me.permissions_submit.next('.spinner').css('visibility', 'hidden');
+        me.permissions_submit.prop('disabled', false);
+        $('.permissions_success').hide();
+        $('.permissions_error').show();
+        $('.permissions_error p').html(data.notice);
+
+      } else if (data.section == 'clear_caches') {
+
+        // Clear Caches section.
+        me.cache_submit.val(cache);
+        me.cache_submit.next('.spinner').css('visibility', 'hidden');
+        me.cache_submit.prop('disabled', false);
+        $('.caches_success').hide();
+        $('.caches_error').show();
+        $('.caches_error p').html(data.notice);
+
+      } else if (data.section == 'auto_sign_in_user') {
+
+        // Shortcode Mode section.
+        me.auto_sign_in_user_submit.val(update);
+        me.auto_sign_in_user_submit.next('.spinner').css('visibility', 'hidden');
+        me.auto_sign_in_user_select.val(data.result);
+        me.auto_sign_in_user_select.prop('disabled', false);
+        $('.auto_sign_in_user_notice').show();
+        $('.auto_sign_in_user_notice p').html(data.notice);
+        me.auto_sign_in_user_selected = data.result;
 
       }
 
-    };
+    }
 
-  }
+  };
 
-  // Init Settings and Buttons classes.
-  var CiviCRM_Options_Settings = new CRM_Settings();
-  var CiviCRM_Options_Buttons = new CRM_Buttons();
-  CiviCRM_Options_Settings.init();
-  CiviCRM_Options_Buttons.init();
+}
 
-  /**
-   * Trigger dom_ready methods where necessary.
-   *
-   * @since 5.34
-   *
-   * @param {Object} $ The jQuery object.
-   */
-  $(document).ready(function($) {
-    CiviCRM_Options_Settings.dom_ready();
-    CiviCRM_Options_Buttons.dom_ready();
-  }); // End document.ready()
+// Init Settings and Buttons classes.
+var CiviCRM_Options_Settings = new CRM_Settings();
+var CiviCRM_Options_Buttons = new CRM_Buttons();
+CiviCRM_Options_Settings.init();
+CiviCRM_Options_Buttons.init();
+
+/**
+ * Trigger dom_ready methods where necessary.
+ *
+ * @since 5.34
+ *
+ * @param {Object} $ The jQuery object.
+ */
+$(document).ready(function($) {
+  CiviCRM_Options_Settings.dom_ready();
+  CiviCRM_Options_Buttons.dom_ready();
+}); // End document.ready()
 
 } )( jQuery );
 

--- a/assets/templates/metaboxes/metabox.options.autosignin.php
+++ b/assets/templates/metaboxes/metabox.options.autosignin.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ *
+ */
+
+// This file must not accessed directly.
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+?><!-- assets/templates/metaboxes/metabox.options.shortcode.php -->
+<?php
+
+/**
+ * Before Shortcode section.
+ *
+ * @since 5.80
+ */
+do_action('civicrm/metabox/autosigninuser/pre');
+
+?>
+<div class="auto_sign_in_user_notice notice notice-error inline" style="background-color: #f7f7f7; display: none;">
+  <p></p>
+</div>
+
+<p><?php esc_html_e('When a WordPress User is created, CiviCRM will automatically log in the user after the creation of the user. This setting lets you choose whether CiviCRM will automatically log the user in after creation. Do you want to allow CiviCRM to automatically log in the user after it is created?', 'civicrm'); ?></p>
+
+<label for="auto_sign_in_user" class="screen-reader-text"><?php esc_html_e('Automatically Sign In User', 'civicrm'); ?></label>
+<select name="auto_sign_in_user" id="auto_sign_in_user">
+  <option value="yes"<?php echo $selected_yes; ?>><?php esc_html_e('Yes', 'civicrm'); ?></option>
+  <option value="no"<?php echo $selected_no; ?>><?php esc_html_e('No', 'civicrm'); ?></option>
+</select>
+
+<p class="submit">
+  <?php submit_button(esc_html__('Saved', 'civicrm'), 'primary hide-if-no-js', 'civicrm_auto_sign_in_user_submit', FALSE, $options_ajax); ?>
+  <?php submit_button(esc_html__('Update', 'civicrm'), 'primary hide-if-js', 'civicrm_auto_sign_in_user_post_submit', FALSE, $options_post); ?>
+  <span class="spinner"></span>
+</p>
+<br class="clear">
+<?php
+
+/**
+ * After Shortcode section.
+ *
+ * @since 5.80
+ */
+do_action('civicrm/metabox/autosigninuser/post');

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -760,7 +760,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
   /**
    * Render "Automatically Sign In User" meta box.
    *
-   * @since 5.80
+   * @since 6.4
    *
    * @param mixed $unused Unused param.
    * @param array $metabox Array containing id, title, callback, and args elements.
@@ -795,7 +795,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     /**
      * Filters the Automatically Sign In User POST submit button attributes.
      *
-     * @since 6.2
+     * @since 6.4
      *
      * @param array $options_post The existing button attributes.
      */
@@ -969,7 +969,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
   /**
    * Save the CiviCRM Automatically Sign In User Setting.
    *
-   * @since 6.2
+   * @since 6.4
    */
   private function form_save_auto_sign_in_user() {
 
@@ -1354,7 +1354,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
   /**
    * Save the CiviCRM Automatically Sign In User Setting.
    *
-   * @since 6.2
+   * @since 6.4
    */
   public function ajax_save_auto_sign_in_user() {
 

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -986,7 +986,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     $auto_sign_in_user = $chosen === 'no' ? FALSE : TRUE;
 
     // Save the setting.
-    update_option('automatically_sign_in_user', $auto_sign_in_user);
+    update_option('automatically_sign_in_user', $auto_sign_in_user, FALSE);
 
   }
 

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -1380,7 +1380,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     }
 
     // Setting is actually a boolean.
-    $auto_sign_in = $chosen === 'no' ? FALSE : TRUE;
+    $auto_sign_in = $chosen === 'no' ? 0 : 1;
 
     // Set the Automatically Sign In User Mode setting.
     $this->civi->admin->set_auto_sign_in_user($auto_sign_in);

--- a/includes/admin-pages/civicrm.page.options.php
+++ b/includes/admin-pages/civicrm.page.options.php
@@ -93,6 +93,7 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     add_action('wp_ajax_civicrm_shortcode', [$this, 'ajax_save_shortcode']);
     add_action('wp_ajax_civicrm_theme_compatibility', [$this, 'ajax_save_theme_compatibility']);
     add_action('wp_ajax_civicrm_email_sync', [$this, 'ajax_save_email_sync']);
+    add_action('wp_ajax_civicrm_auto_sign_in_user', [$this, 'ajax_save_auto_sign_in_user']);
     add_action('wp_ajax_civicrm_refresh_permissions', [$this, 'ajax_refresh_permissions']);
     add_action('wp_ajax_civicrm_clear_caches', [$this, 'ajax_clear_caches']);
 
@@ -381,6 +382,17 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
       'civicrm_options_emailinks',
       __('Useful Links', 'civicrm'),
       [$this, 'meta_box_options_links_render'],
+      $screen_id,
+      'side',
+      'core',
+      $data
+    );
+
+    // Create "Automatically Sign In New User" metabox.
+    add_meta_box(
+      'civicrm_options_auto_sign_in_user',
+      __('Automatically Sign In New User', 'civicrm'),
+      [$this, 'meta_box_options_auto_sign_in_user_render'],
       $screen_id,
       'side',
       'core',
@@ -745,6 +757,55 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
 
   }
 
+  /**
+   * Render "Automatically Sign In User" meta box.
+   *
+   * @since 5.80
+   *
+   * @param mixed $unused Unused param.
+   * @param array $metabox Array containing id, title, callback, and args elements.
+   */
+  public function meta_box_options_auto_sign_in_user_render($unused, $metabox) {
+
+    if (!$this->civi->initialize()) {
+      return;
+    }
+
+    // Get the Shortcode Theme Compatibility setting.
+    $auto_sign_in_mode = $this->civi->admin->get_auto_sign_in_mode();
+
+    // Set selected attributes.
+
+    // Set selected attributes.
+    $selected_yes = $auto_sign_in_mode ? 'selected="selected"' : '';
+    $selected_no = $auto_sign_in_mode ? '' : 'selected="selected"';
+
+    // Set AJAX submit button options.
+    $options_ajax = [
+      'style' => 'float: right;',
+      'data-security' => esc_attr(wp_create_nonce('civicrm_auto_sign_in_user')),
+      'disabled' => NULL,
+    ];
+
+    // Set POST submit button options.
+    $options_post = [
+      'style' => 'float: right;',
+    ];
+
+    /**
+     * Filters the Automatically Sign In User POST submit button attributes.
+     *
+     * @since 6.2
+     *
+     * @param array $options_post The existing button attributes.
+     */
+    $options_post = apply_filters('civicrm/metabox/autosigninuser/submit/options', $options_post);
+
+    // Include template file.
+    include CIVICRM_PLUGIN_DIR . 'assets/templates/metaboxes/metabox.options.autosignin.php';
+
+  }
+
   // ---------------------------------------------------------------------------
   // Form Handlers
   // ---------------------------------------------------------------------------
@@ -794,6 +855,12 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
       // Clear caches.
       $this->form_nonce_check();
       $this->civi->admin->clear_caches();
+      $this->form_redirect();
+    }
+    elseif (!empty($_POST['civicrm_auto_sign_in_user_post_submit'])) {
+      // Save Email Sync.
+      $this->form_nonce_check();
+      $this->form_save_auto_sign_in_user();
       $this->form_redirect();
     }
 
@@ -896,6 +963,30 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     civicrm_api3('Setting', 'create', [
       'syncCMSEmail' => $sync_email,
     ]);
+
+  }
+
+  /**
+   * Save the CiviCRM Automatically Sign In User Setting.
+   *
+   * @since 6.2
+   */
+  private function form_save_auto_sign_in_user() {
+
+    // Bail if there is no valid chosen value.
+    // Nonce is checked in self::form_nonce_check().
+    // phpcs:disable WordPress.Security.NonceVerification.Missing
+    $chosen = isset($_POST['auto_sign_in_user']) ? sanitize_text_field(wp_unslash($_POST['auto_sign_in_user'])) : 0;
+    // phpcs:enable WordPress.Security.NonceVerification.Missing
+    if ($chosen === 0) {
+      return;
+    }
+
+    // Setting is actually a boolean.
+    $auto_sign_in_user = $chosen === 'no' ? FALSE : TRUE;
+
+    // Save the setting.
+    update_option('automatically_sign_in_user', $auto_sign_in_user);
 
   }
 
@@ -1252,6 +1343,53 @@ class CiviCRM_For_WordPress_Admin_Page_Options {
     $data = [
       'section' => 'clear_caches',
       'notice' => __('CiviCRM caches cleared.', 'civicrm'),
+      'saved' => TRUE,
+    ];
+
+    // Return the data.
+    wp_send_json($data);
+
+  }
+
+  /**
+   * Save the CiviCRM Automatically Sign In User Setting.
+   *
+   * @since 6.2
+   */
+  public function ajax_save_auto_sign_in_user() {
+
+    // Default response.
+    $data = [
+      'section' => 'auto_sign_in_user',
+      'message' => __('Could not save the selected setting.', 'civicrm'),
+      'saved' => FALSE,
+    ];
+
+    // Since this is an AJAX request, check security.
+    $result = check_ajax_referer('civicrm_auto_sign_in_user', FALSE, FALSE);
+    if ($result === FALSE) {
+      $data['notice'] = __('Authentication failed. Could not save the selected setting.', 'civicrm');
+      wp_send_json($data);
+    }
+
+    // Bail if there is no valid chosen value.
+    $chosen = isset($_POST['value']) ? sanitize_text_field(wp_unslash($_POST['value'])) : 0;
+    if ($chosen === 0) {
+      $data['notice'] = __('Unrecognised parameter. Could not save the selected setting.', 'civicrm');
+      wp_send_json($data);
+    }
+
+    // Setting is actually a boolean.
+    $auto_sign_in = $chosen === 'no' ? FALSE : TRUE;
+
+    // Set the Automatically Sign In User Mode setting.
+    $this->civi->admin->set_auto_sign_in_user($auto_sign_in);
+
+    // Data response.
+    $data = [
+      'section' => 'auto_sign_in_user',
+      'result' => $chosen,
+      'message' => __('Setting saved.', 'civicrm'),
       'saved' => TRUE,
     ];
 

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -1005,4 +1005,28 @@ class CiviCRM_For_WordPress_Admin {
     return ['loop', 'filter'];
   }
 
+  /**
+   * Gets the CiviCRM Automatically Sign In User Setting.
+   *
+   * Defaults to TRUE to preserve existing behaviour.
+   *
+   * @since 6.2
+   *
+   * @return bool $automatically_sign_in_user Whether to Automatically Sign In the WP User after it is created.
+   */
+  public function get_auto_sign_in_mode() {
+    return get_option('civicrm_automatically_sign_in_user', TRUE);
+  }
+
+  /**
+   * Sets the CiviCRM Automatically Sign In User Setting.
+   *
+   * @since 6.2
+   *
+   * @param bool $automatically_sign_in_user Whether to Automatically Sign In the WP User after it is created.
+   */
+  public function set_auto_sign_in_user($automatically_sign_in_user) {
+    update_option('civicrm_automatically_sign_in_user', $automatically_sign_in_user);
+  }
+
 }

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -1026,7 +1026,7 @@ class CiviCRM_For_WordPress_Admin {
    * @param bool $automatically_sign_in_user Whether to Automatically Sign In the WP User after it is created.
    */
   public function set_auto_sign_in_user($automatically_sign_in_user) {
-    update_option('civicrm_automatically_sign_in_user', $automatically_sign_in_user);
+    update_option('civicrm_automatically_sign_in_user', $automatically_sign_in_user, FALSE);
   }
 
 }

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -1015,7 +1015,7 @@ class CiviCRM_For_WordPress_Admin {
    * @return bool $automatically_sign_in_user Whether to Automatically Sign In the WP User after it is created.
    */
   public function get_auto_sign_in_mode() {
-    return get_option('civicrm_automatically_sign_in_user', TRUE);
+    return boolval(get_option('civicrm_automatically_sign_in_user', TRUE));
   }
 
   /**


### PR DESCRIPTION
## Automatically Sign In WP User setting

Depends on https://github.com/civicrm/civicrm-core/pull/32861

Overview
----------------------------------------
_This will add a new setting option in the WP CiviCRM settings screen which will allow the site to control whether or not the new WP user will be automatically logged in when their user account is created._

Before
----------------------------------------
_Currently, when a new WP user is created from a membership/contribution, after creating the WP User, it will automatically log the user in._

After
----------------------------------------
_With the new CiviCRM setting, 'Automatically Sign In User', you can now control whether you would like to allow the default behavior or prevent the auto login from happening._

Technical Details
----------------------------------------
_We have added new WP option that can ideally control whether or not a user will be automatically logged in after their user account is created. This new option requires a change with the CiviCRM Core Wordpress class that will leverage this new option._

