### PR TITLE
NFC: Introduce hooks before and after loading settings file

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -299,6 +299,8 @@ class CiviCRM_For_WordPress {
    * Checks for iframe requests.
    *
    * @since 6.0.0
+   *
+   * @return bool True if this is an iframe request, false otherwise.
    */
   protected function is_iframe(): bool {
     if (is_admin()) {

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -391,8 +391,30 @@ class CiviCRM_For_WordPress_Admin {
      * file, we now know it is there.
      */
 
+    /**
+     * Fires before the CiviCRM settings file has been included.
+     *
+     * Plugins can use this action to define constants before they are set
+     * in the CiviCRM settings file. This is only effective when WordPress
+     * has not been externally bootstrapped e.g. via `extern/*.php`.
+     *
+     * @since 6.6.0
+     */
+    do_action('civicrm_before_settings_file_load');
+
     // Include settings file - returns int(1) on success.
     $error = include_once CIVICRM_SETTINGS_PATH;
+
+    /**
+     * Fires after the CiviCRM settings file has been included.
+     *
+     * Plugins can use this action to override settings that have been set in
+     * the CiviCRM settings file. This is only effective when WordPress has not
+     * been externally bootstrapped e.g. via `extern/*.php`.
+     *
+     * @since 6.6.0
+     */
+    do_action('civicrm_after_settings_file_load');
 
     /*
      * Bail if the settings file returns something other than int(1).


### PR DESCRIPTION
Overview
----------------------------------------
With these two actions, plugins can override both the constants and settings that are set in `civicrm.settings.php`. NFC unless callbacks to these actions are implemented.

Before
----------------------------------------
Plugins cannot override constants and settings.

After
----------------------------------------
Plugins can override constants and settings.

Technical Details
----------------------------------------
This change is ultimately aimed at making the use of `civicrm_multisite_get_domain_data()` unnecessary when there are multiple CiviCRM Domains, e.g.

```php
// Set Base URL dynamically.
add_action( 'civicrm_before_settings_file_load', 'my_civicrm_before_settings_file_load', 10 );
function my_civicrm_before_settings_file_load() {
	if ( ! defined( 'CIVICRM_UF_BASEURL' ) ) {
		define( 'CIVICRM_UF_BASEURL', untrailingslashit( home_url() ) );
	}
}

// Set known CiviCRM paths dynamically.
add_action( 'civicrm_after_settings_file_load', 'my_civicrm_after_settings_file_load', 10 );
function my_civicrm_after_settings_file_load() {
	global $civicrm_paths;
	$civicrm_paths['wp.frontend.base']['url'] = trailingslashit( home_url() );
	$civicrm_paths['wp.backend.base']['url']  = trailingslashit( admin_url() );
}
```

Setting `CIVICRM_DOMAIN_ID` dynamically is a bit more complicated - it still needs correspondences of the kind that `civicrm_multisite_get_domain_data()` implements. CiviCRM Admin Utilities will provide this mapping once these actions are available.