### PR TITLE
Avoid starting a PHP session unless necessary

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -485,9 +485,6 @@ class CiviCRM_For_WordPress {
       wp_die(__('Only one instance of CiviCRM_For_WordPress please', 'civicrm'));
     }
 
-    // Maybe start session.
-    $this->maybe_start_session();
-
     /*
      * AJAX calls do not set the 'cms.root' item, so make sure it is set here so
      * the CiviCRM doesn't fall back on flaky directory traversal code.
@@ -659,6 +656,11 @@ class CiviCRM_For_WordPress {
     // Store identifying query var.
     $page = get_query_var('civiwp');
     self::$in_wordpress = ($page === 'CiviCRM') ? TRUE : FALSE;
+
+    // Avoid starting a session if not necessary
+    if (self::$in_wordpress) {
+      $this->maybe_start_session();
+    }
 
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM was previously always starting a PHP session, even on pages that did not have CiviCRM forms, which would then impact the performance of the site in general since most caches will not work if there is a session.

Before
----------------------------------------

PHPSESSION always started.

After
----------------------------------------

PHPSESSION only started on pages with CiviCRM. Tested with:

- frontend pages with shortcode
- frontend pages native
- backend

Comments
----------------------------------------

- I don't know much about WordPress, so please test!
- When we logout, the cookie is not deleted. So to test correctly, it's important to manually delete the cookie (web tools -> storage -> cookies). While it would be best to delete the cookie, this is already a step forward, because it allows caching for 99% of traffic (i.e. folks and bots who do not login to the site).