### PR TITLE
Alternative way to avoid starting a PHP session unless necessary

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -485,9 +485,6 @@ class CiviCRM_For_WordPress {
       wp_die(__('Only one instance of CiviCRM_For_WordPress please', 'civicrm'));
     }
 
-    // Maybe start session.
-    $this->maybe_start_session();
-
     /*
      * AJAX calls do not set the 'cms.root' item, so make sure it is set here so
      * the CiviCRM doesn't fall back on flaky directory traversal code.
@@ -710,6 +707,9 @@ class CiviCRM_For_WordPress {
 
     // Store.
     self::$context = $context;
+
+    // Maybe start session.
+    $this->maybe_start_session();
 
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to #352 that starts sessions for URLs where Shortcodes are embedded but the query variables are not yet set.

Before
----------------------------------------

PHPSESSION always started.

After
----------------------------------------

PHPSESSION only started on pages with CiviCRM content.

Comments
----------------------------------------
See #352 for discussion.