### PR TITLE
Composer install no settings file

### DIFF
--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -274,10 +274,17 @@ class CiviCRM_For_WordPress_Admin {
     }
 
     $vendor_setup_paths = [];
-    $civicrm_plugin_dir_array = explode(DIRECTORY_SEPARATOR, CIVICRM_PLUGIN_DIR);
-    foreach ($civicrm_plugin_dir_array as $directory_component) {
-      $vendor_setup_paths[] = $directory_component;
-      $civicrm_core_path = implode(DIRECTORY_SEPARATOR, array_merge($vendor_setup_paths, ['vendor', 'civicrm', 'civicrm-core']));
+    $filtered_paths = array_values(array_filter(explode(DIRECTORY_SEPARATOR, CIVICRM_PLUGIN_DIR)));
+    $potential_vendor_paths = [];
+    $count = count($filtered_paths);
+    for ($i = 0; $i <= $count; $i++) {
+      if ($i < $count) {
+        $slice = array_slice($filtered_paths, 0, $count - $i);
+        $potential_vendor_paths[] = '/' . implode('/', $slice);
+      }
+    }
+    foreach ($potential_vendor_paths as $potential_path) {
+      $civicrm_core_path = implode(DIRECTORY_SEPARATOR, array_merge(explode(DIRECTORY_SEPARATOR, $potential_path), ['vendor', 'civicrm', 'civicrm-core']));
       $civicrm_setup_autoload_path = $civicrm_core_path . DIRECTORY_SEPARATOR . 'setup' . DIRECTORY_SEPARATOR . 'civicrm-setup-autoload.php';
       $civicrm_classloader_path = $civicrm_core_path . DIRECTORY_SEPARATOR . 'CRM' . DIRECTORY_SEPARATOR . 'Core' . DIRECTORY_SEPARATOR . 'ClassLoader.php';
       if (file_exists($civicrm_setup_autoload_path)) {

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -295,6 +295,7 @@ class CiviCRM_For_WordPress_Admin {
         \Civi\Setup::init([
           'cms' => 'WordPress',
           'srcPath' => $civicrm_core_path,
+          'doNotCreateSettingsFile' => TRUE,
         ]);
         $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
         $ctrl->setUrls([


### PR DESCRIPTION
Overview
----------------------------------------
Slight modification of https://github.com/civicrm/civicrm-wordpress/pull/349
Adds doNotCreateSettingsFile=TRUE flag, supported in Core, to setup for composer installs, where existing civicrm.settings.php does not throw an error for install

