### PR TITLE
Enable Sample Data to be loaded when activating CiviCRM

### DIFF
--- a/wp-cli/commands/command-core.php
+++ b/wp-cli/commands/command-core.php
@@ -86,6 +86,9 @@ class CLI_Tools_CiviCRM_Command_Core extends CLI_Tools_CiviCRM_Command {
    * [--site-url=<site-url>]
    * : Domain for your website, e.g. 'mysite.com'.
    *
+   * [--sample-data]
+   * : Load sample data about fake people. Only available in "en_US" locale.
+   *
    * [--yes]
    * : Answer yes to the confirmation message.
    *
@@ -156,6 +159,7 @@ class CLI_Tools_CiviCRM_Command_Core extends CLI_Tools_CiviCRM_Command {
     $locale = (string) \WP_CLI\Utils\get_flag_value($assoc_args, 'locale', 'en_US');
     $ssl = (string) \WP_CLI\Utils\get_flag_value($assoc_args, 'ssl', 'on');
     $base_url = (string) \WP_CLI\Utils\get_flag_value($assoc_args, 'site-url', '');
+    $sample_data = (bool) \WP_CLI\Utils\get_flag_value($assoc_args, 'sample-data', FALSE);
 
     // Show database parameters.
     WP_CLI::log(WP_CLI::colorize('%GCiviCRM database credentials:%n'));
@@ -215,6 +219,11 @@ class CLI_Tools_CiviCRM_Command_Core extends CLI_Tools_CiviCRM_Command {
       $protocol = ('on' === $ssl ? 'https' : 'http');
       $base_url = $protocol . '://' . $base_url;
       $setup->getModel()->cmsBaseUrl = trailingslashit($base_url);
+    }
+
+    // Maybe load sample data.
+    if ($locale === 'en_US' && $sample_data) {
+      $setup->getModel()->loadGenerated = TRUE;
     }
 
     // Validate system requirements.


### PR DESCRIPTION
Overview
----------------------------------------
@kcristiano Seems I forgot to include this in the last WP-CLI update.

Before
----------------------------------------
Cannot load Sample Data.

After
----------------------------------------
Able to load Sample Data.