### PR TITLE
Prevent WordPress emoji script from loading on CiviCRM admin screens

### DIFF
--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -677,6 +677,9 @@ class CiviCRM_For_WordPress_Admin {
       // Add core resources prior to page load.
       add_action('load-' . $this->menu_page, [$this, 'admin_page_load']);
 
+      // Disable emoji script.
+      add_action('load-' . $this->menu_page, [$this, 'disable_emoji_script']);
+
     }
     else {
 
@@ -797,6 +800,18 @@ class CiviCRM_For_WordPress_Admin {
 
     // Add resources for back end.
     $this->civi->add_core_resources(FALSE);
+
+  }
+
+  /**
+   * Disables the WordPress emoji script on CiviCRM's admin pages.
+   *
+   * @since 6.16
+   */
+  public function disable_emoji_script() {
+
+    remove_action('admin_print_scripts', 'print_emoji_detection_script');
+    remove_action('admin_print_styles', 'print_emoji_styles');
 
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Prevent WordPress emoji detection script from auto-replacing certain glyphs with emoji image tags.

Before
----------------------------------------
WordPress development version (7.1-alpha-62415) replaces the left arrow glyph with a left arrow emoji image in SearchKit pagination:

<img width="1540" height="188" alt="Screenshot 2026-05-25 at 11 28 58" src="https://github.com/user-attachments/assets/e84021e4-7bb5-4f8d-98cb-474c91b8040c" />

An`<img>` tag is injected inside the previous page anchor:

```html
<a href="" ng-click="selectPage(page - 1, $event)" ng-disabled="noPrevious()||ngDisabled" uib-tabindex-toggle="" class="ng-binding" disabled="disabled" tabindex="-1">
  <img draggable="false" role="img" class="emoji" alt="⬅" src="https://s.w.org/images/core/emoji/17.0.2/svg/2b05.svg">
</a>
```

So far, this is the only glyph that I have found that is replaced. I haven't discovered why, but I highly doubt that the WordPress emoji detection script is helpful on CiviCRM admin screens. @kcristiano Have you seen any use of emoji that is helpful?

After
----------------------------------------
No substitution takes place.

<img width="1541" height="215" alt="Screenshot 2026-05-25 at 11 38 02" src="https://github.com/user-attachments/assets/fa946e7f-f1d7-45f9-ba3a-a356ca92a183" />

Markup is now unaffected:

```html
<a href="" ng-click="selectPage(page - 1, $event)" ng-disabled="noPrevious()||ngDisabled" uib-tabindex-toggle="" class="ng-binding" disabled="disabled" tabindex="-1">⬅</a>
```

Comments
----------------------------------------
FWIW, this happens on my "Wellow Brook" RiverLea stream, but does not happen with vanilla RiverLea streams (or Greenwich or Radstock) in a CiviCRM-only install. It could be an interaction with another plugin or theme (my Wellow Brook dev site has quite a few to make sure it supports their CiviCRM modifications) so may not be easily reproducible. However this PR seems like a sensible defensive move to prevent unwanted emoji substitutions regardless.