### PR TITLE
do not require check for or creation of civicrm.settings.php to allow…

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -103,6 +103,54 @@ else {
 }
 
 /**
+ * Determine whether CiviCRM's database schema has actually been bootstrapped.
+ *
+ * In Bedrock-style deployments, civicrm.settings.php may be shipped as a
+ * template (driven by env vars) before the database has ever been initialized.
+ * In that case CIVICRM_INSTALLED is TRUE but the schema is empty. Without this
+ * check, the activation hook would skip the installer redirect and admin
+ * bootstrap would later fail trying to read from a missing schema.
+ *
+ * Probes the civicrm_domain table on CIVICRM_DSN. Cached per-request.
+ */
+if (!function_exists('civicrm_schema_is_installed')) {
+  function civicrm_schema_is_installed() {
+    static $cached = NULL;
+    if ($cached !== NULL) {
+      return $cached;
+    }
+    if (!CIVICRM_INSTALLED) {
+      return $cached = FALSE;
+    }
+    if (!defined('CIVICRM_DSN')) {
+      @include_once CIVICRM_SETTINGS_PATH;
+    }
+    if (!defined('CIVICRM_DSN')) {
+      return $cached = FALSE;
+    }
+    $dsn = @parse_url(CIVICRM_DSN);
+    if (empty($dsn['host']) || empty($dsn['user']) || empty($dsn['path'])) {
+      return $cached = FALSE;
+    }
+    $db_name = ltrim($dsn['path'], '/');
+    $port = !empty($dsn['port']) ? (int) $dsn['port'] : 3306;
+    try {
+      $mysqli = @new mysqli($dsn['host'], $dsn['user'], $dsn['pass'] ?? '', $db_name, $port);
+      if ($mysqli->connect_errno) {
+        return $cached = FALSE;
+      }
+      $result = @$mysqli->query("SHOW TABLES LIKE 'civicrm_domain'");
+      $found = ($result && $result->num_rows > 0);
+      $mysqli->close();
+      return $cached = (bool) $found;
+    }
+    catch (\Throwable $e) {
+      return $cached = FALSE;
+    }
+  }
+}
+
+/**
  * Setting this to 'TRUE' will replace all mailing URLs calls to 'extern/url.php'
  * and 'extern/open.php' with their REST counterpart 'civicrm/v3/url' and
  * 'civicrm/v3/open'.
@@ -435,7 +483,7 @@ class CiviCRM_For_WordPress {
     // When installed via the WordPress UI, try and redirect to the Installer page.
     // phpcs:ignore WordPress.Security.NonceVerification.Recommended
     $activate_multi = isset($_GET['activate-multi']) ? sanitize_text_field(wp_unslash($_GET['activate-multi'])) : '';
-    if (!is_multisite() && empty($activate_multi) && !CIVICRM_INSTALLED) {
+    if (!is_multisite() && empty($activate_multi) && (!CIVICRM_INSTALLED || !civicrm_schema_is_installed())) {
       wp_safe_redirect(admin_url('admin.php?page=civicrm-install'));
       exit;
     }

--- a/includes/civicrm.admin.php
+++ b/includes/civicrm.admin.php
@@ -295,7 +295,63 @@ class CiviCRM_For_WordPress_Admin {
         \Civi\Setup::init([
           'cms' => 'WordPress',
           'srcPath' => $civicrm_core_path,
+          'doNotCreateSettingsFile' => TRUE,
         ]);
+        // Bedrock-style deployments ship civicrm.settings.php as a template,
+        // so its presence does not imply CiviCRM has been installed. Force
+        // setSettingInstalled(FALSE) so only the database check gates whether
+        // SetupController::runStart() short-circuits to the "finished" page.
+        \Civi\Setup::dispatcher()->addListener(
+          'civi.setup.checkInstalled',
+          function (\Civi\Setup\Event\CheckInstalledEvent $e) {
+            $e->setSettingInstalled(FALSE);
+          },
+          -1000
+        );
+        // The default checkRequirements listener errors when the settings file
+        // path isn't writable. When doNotCreateSettingsFile is set, the file is
+        // managed externally and writability is irrelevant — overwrite the
+        // 'settingsWritable' message (keyed by name) with an info entry.
+        \Civi\Setup::dispatcher()->addListener(
+          'civi.setup.checkRequirements',
+          function (\Civi\Setup\Event\CheckRequirementsEvent $e) {
+            $m = $e->getModel();
+            if (!empty($m->doNotCreateSettingsFile)) {
+              $e->addInfo('system', 'settingsWritable', sprintf('The settings file "%s" is managed externally; writability is not checked.', $m->settingsPath));
+            }
+          },
+          -1000
+        );
+        // The default WordPress init listener sets $model->db to the WP
+        // database creds. When CIVICRM_DSN is already defined (Bedrock-style
+        // templated settings file), prefer that — the CiviCRM database is
+        // typically separate from the WordPress one. The civi.setup.init event
+        // is dispatched inside \Civi\Setup::init() before listeners can be
+        // attached, so mutate the model directly.
+        if (!defined('CIVICRM_DSN') && file_exists(CIVICRM_SETTINGS_PATH)) {
+          @include_once CIVICRM_SETTINGS_PATH;
+        }
+        if (defined('CIVICRM_DSN')) {
+          $civi_dsn_parsed = \Civi\Setup\DbUtil::parseDsn(CIVICRM_DSN);
+          \Civi\Setup::instance()->getModel()->db = $civi_dsn_parsed;
+          \Civi\Setup::instance()->getModel()->extras['advanced']['db'] = \Civi\Setup\DbUtil::encodeDsn($civi_dsn_parsed);
+        }
+        // Keep the editable "advanced.db" field in sync with $model->db when
+        // the user hasn't typed their own value yet — the default advanced
+        // listener at PRIORITY_LATE forces the input back to a placeholder, so
+        // run after it (PRIORITY_END = -2000).
+        \Civi\Setup::dispatcher()->addListener(
+          'civi.setupui.run',
+          function (\Civi\Setup\UI\Event\UIBootEvent $e) {
+            $model = $e->getModel();
+            $placeholder = 'mysql://USER:PASS@HOST/DB';
+            $values = $e->getField('advanced', []);
+            if (empty($values['db']) || $values['db'] === $placeholder) {
+              $model->extras['advanced']['db'] = \Civi\Setup\DbUtil::encodeDsn($model->db);
+            }
+          },
+          \Civi\Setup::PRIORITY_END
+        );
         $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
         $ctrl->setUrls([
           'ctrl' => menu_page_url('civicrm-install', FALSE),
@@ -409,6 +465,18 @@ class CiviCRM_For_WordPress_Admin {
      * reason, the initial redirect on install hasn't occured.
      */
     if (!CIVICRM_INSTALLED) {
+      $this->error_flag = 'settings-missing';
+      $initialized = FALSE;
+      return FALSE;
+    }
+
+    /*
+     * Settings file exists, but the database schema may not have been
+     * bootstrapped yet (e.g. Bedrock layouts that ship a templated settings
+     * file driven by env vars). In that case route to the installer rather
+     * than attempting to bootstrap CiviCRM against an empty schema.
+     */
+    if (function_exists('civicrm_schema_is_installed') && !civicrm_schema_is_installed()) {
       $this->error_flag = 'settings-missing';
       $initialized = FALSE;
       return FALSE;


### PR DESCRIPTION
… using a template, do check if civicrm database tables exist in the civicrm.settings.php CIVICRM_DSN

Overview
----------------------------------------
Now that composer based installations are supported, a next step is leveling up support for automatic deployments to PaaS systems with read only file systems such as Upsun. 

For many years the CiviCRM Wordpress plugin installation has checked for whether a civicrm.settings.php exists to determine if CiviCRM was already installed, and if so, then stop the installation process. 

This PR checks to see if a CIVICRM_DSN is defined via a civicrm.settings.php file, and if so, checks to see if "civicrm_" tables exist in that database. If not, proceed with installation, if so, halt the installation. 

The PR only does this for composer based installations, that is when civicrm-core is discovered in a vendor directory. 
Standard installs are not affected.

Before
----------------------------------------
Installing CiviCRM on PaaS with civicrm.settings.php template provided in repo impossible.

After
----------------------------------------
Installation is possible

Technical Details
----------------------------------------
Interesting tangent: https://lab.civicrm.org/dev/wordpress/-/work_items/162
Will update this PR and/or template below based on that work.

Replaces: https://github.com/civicrm/civicrm-wordpress/pull/362

Comments
----------------------------------------
Full example composer template: https://github.com/Skvare/upsun-wordpress-bedrock-civicrm-template

Detailed blog article explaining this: https://github.com/jackrabbithanna/wordpress-bedrock-civicrm-upsun-blog/blob/main/civicrm-wordpress-bedrock-on-upsun.md
