### PR TITLE
bump stable version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: needle
 Tags: civicrm, crm
 Requires at least: 6.3
 Tested up to: 6.9
-Stable tag: 6.12
+Stable tag: 6.15
 License: AGPL3
 License URI: http://www.gnu.org/licenses/agpl-3.0.html
 


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/35799   we are now setting versions automatically.  This will be the last time we manually set the version. 

